### PR TITLE
type definitions -- update onData handle, allow for user data to be attached to response

### DIFF
--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -33,6 +33,9 @@ interface WebSocket {
 
     /** Returns the remote IP address */
     getRemoteAddress() : ArrayBuffer;
+    
+    /** Arbitrary user data may be attached to this object */
+    [key: string]: any;
 }
 
 /** An HttpResponse is valid until either onAborted callback or any of the .end/.tryEnd calls succeed. You may attach user data to this object. */

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -67,10 +67,13 @@ interface HttpResponse {
     onAborted(handler: (res: HttpResponse) => void) : HttpResponse;
 
     /** Handler for reading data from POST and such requests. You MUST copy the data of chunk if isLast is not true. We Neuter ArrayBuffers on return, making it zero length.*/
-    onData(handler: (res: HttpResponse, chunk: ArrayBuffer, isLast: boolean) => void) : HttpResponse;
+    onData(handler: (chunk: ArrayBuffer, isLast: boolean) => void) : HttpResponse;
 
     /** Returns the remote IP address */
     getRemoteAddress() : ArrayBuffer;
+
+    /** Arbitrary user data may be attached to this object */
+    [key: string]: any;
 }
 
 /** An HttpRequest is stack allocated and only accessible during the callback invocation. */


### PR DESCRIPTION
Based on the usage I think that the onData handler is typed incorrectly and currently the types don't allow for user data to be attached to the response unless asserted as `all`.