### PR TITLE
Fixes TypeScript projects with noImplicitAny true

### DIFF
--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -92,7 +92,7 @@ interface HttpRequest {
     /** Returns the part of URL after ? sign or empty string. */
     getQuery() : string;
     /** Loops over all headers. */
-    forEach(cb: (key: string, value: string) => void);
+    forEach(cb: (key: string, value: string) => void) : void;
 }
 
 /** A structure holding settings and handlers for a WebSocket route handler. */


### PR DESCRIPTION
When tsconfig.json contains `"noImplicitAny": true` in a project that uses `uWebSockets.js` as a dependency from `node_modules` TypeScript compilation fails with the error:
```
node_modules/uWebSockets.js/index.d.ts:95:5 - error TS7010: 'forEach', which lacks return-type annotation, implicitly has an 'any' return type.

95     forEach(cb: (key: string, value: string) => void);
```