### PR TITLE
Modify listen() to support the optional `options` argument

### DIFF
--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -171,3 +171,9 @@ export enum CompressOptions {
     /** Sliding dedicated compress window, requires lots of memory per socket */
     DEDICATED_COMPRESSOR
 }
+
+/** WebSocket listen() options */
+export enum ListenOptions {
+    /* SO_REUSEPORT disabled */
+    OPTION_DO_NOT_REUSE_PORT = 2
+}

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -89,6 +89,9 @@ void Main(Local<Object> exports) {
     exports->Set(String::NewFromUtf8(isolate, "SHARED_COMPRESSOR"), Integer::NewFromUnsigned(isolate, uWS::SHARED_COMPRESSOR));
     exports->Set(String::NewFromUtf8(isolate, "DEDICATED_COMPRESSOR"), Integer::NewFromUnsigned(isolate, uWS::DEDICATED_COMPRESSOR));
 
+    /* Listen enum */
+    exports->Set(String::NewFromUtf8(isolate, "OPTION_DO_NOT_REUSE_PORT"), Integer::NewFromUnsigned(isolate, uWS::OPTION_DO_NOT_REUSE_PORT));
+
     /* The template for websockets */
     WebSocketWrapper::initWsTemplate<0>();
     WebSocketWrapper::initWsTemplate<1>();


### PR DESCRIPTION
Depends on https://github.com/uNetworking/uSockets/pull/48 and https://github.com/uNetworking/uWebSockets/pull/879

Fixes https://github.com/uNetworking/uWebSockets.js/issues/118 from @davidmurdoch, this PR adds the ability for users to provide the optional `options` parameter from the JS side and handles the redirection to C appropriately.

Feel free to edit the code directly as you see fit @alexhultman 