### PR TITLE
update json/body parser example

### DIFF
--- a/examples/JsonPost.js
+++ b/examples/JsonPost.js
@@ -33,5 +33,5 @@ function readBody(res, cb) {
   res.onData((arrayBuffer, isLast) => {
     body = Buffer.concat([body, Buffer.from(arrayBuffer)]);
     if (isLast) cb(body);
-  })
+  });
 }

--- a/examples/JsonPost.js
+++ b/examples/JsonPost.js
@@ -1,37 +1,37 @@
 /* Simple example for reading Post body and parsing Json */
 
-const uWS = require('../dist/uws.js')
-const port = 9001
+const uWS = require('../dist/uws.js');
+const port = 9001;
 const app = uWS.App().post('/json', (res, req) => {
 
   /* onAborted needs to be set if doing anything async like reading body */
-  res.onAborted(() => res.aborted = true)
+  res.onAborted(() => res.aborted = true);
 
   /* read the request body */
   readBody(res, body => {
 
     /* get body text as string */
-    console.log('body text:', body.toString())
+    console.log('body text:', body.toString());
 
     /* parse json */
-    try { var obj = JSON.parse(body) }
-    catch(e) { console.log('json parse error') }
-    console.log('json object:', obj)
+    try { var obj = JSON.parse(body); }
+    catch(e) { console.log('json parse error'); }
+    console.log('json object:', obj);
 
     /* if response was aborted can't use it */
-    if (res.aborted) return
+    if (res.aborted) return;
 
     /* respond to request */
-    if (!obj) return res.writeStatus('400').end('invalid json')
-    res.end('success')
-  })
-}).listen(port, token => token && console.log('Listening to port ' + port))
+    if (!obj) return res.writeStatus('400').end('invalid json');
+    res.end('success');
+  });
+}).listen(port, token => token && console.log('Listening to port ' + port));
 
 /* Helper function for reading body */
 function readBody(res, cb) {
-  let body = Buffer.from([])
+  let body = Buffer.from([]);
   res.onData((arrayBuffer, isLast) => {
-    body = Buffer.concat([body, Buffer.from(arrayBuffer)])
-    if (isLast) cb(body)
+    body = Buffer.concat([body, Buffer.from(arrayBuffer)]);
+    if (isLast) cb(body);
   })
 }


### PR DESCRIPTION
update the json body parse example with better `readBody` helper function, use tabs not spaces, simplify code
```
/* Simple example for reading Post body and parsing Json */

const uWS = require('../dist/uws.js');
const port = 9001;
const app = uWS.App().post('/json', (res, req) => {

  /* onAborted needs to be set if doing anything async like reading body */
  res.onAborted(() => res.aborted = true);

  /* read the request body */
  readBody(res, body => {

    /* get body text as string */
    console.log('body text:', body.toString());

    /* parse json */
    try { var obj = JSON.parse(body); }
    catch(e) { console.log('json parse error'); }
    console.log('json object:', obj);

    /* if response was aborted can't use it */
    if (res.aborted) return;

    /* respond to request */
    if (!obj) return res.writeStatus('400').end('invalid json');
    res.end('success');
  });
}).listen(port, token => token && console.log('Listening to port ' + port));

/* Helper function for reading body */
function readBody(res, cb) {
  let body = Buffer.from([]);
  res.onData((arrayBuffer, isLast) => {
    body = Buffer.concat([body, Buffer.from(arrayBuffer)]);
    if (isLast) cb(body);
  });
}
```