### PR TITLE
export typescript types and interfaces

### DIFF
--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -1,15 +1,15 @@
 /* Under construction, lots of things to add */
 
 /** Native type representing a raw uSockets struct us_listen_socket. */
-interface us_listen_socket {
+export interface us_listen_socket {
 
 }
 
 /** Recognized string types, things C++ can read and understand as strings */
-type RecognizedString = string | ArrayBuffer | Uint8Array | Int8Array | Uint16Array | Int16Array | Uint32Array | Int32Array | Float32Array | Float64Array;
+export type RecognizedString = string | ArrayBuffer | Uint8Array | Int8Array | Uint16Array | Int16Array | Uint32Array | Int32Array | Float32Array | Float64Array;
 
 /** A WebSocket connection that is valid from open to close event */
-interface WebSocket {
+export interface WebSocket {
     /** Sends a message. Make sure to check getBufferedAmount() before sending. Returns true for success, false for built up backpressure that will drain when time is given. */
     send(message: RecognizedString, isBinary?: boolean, compress?: boolean) : boolean;
 
@@ -39,7 +39,7 @@ interface WebSocket {
 }
 
 /** An HttpResponse is valid until either onAborted callback or any of the .end/.tryEnd calls succeed. You may attach user data to this object. */
-interface HttpResponse {
+export interface HttpResponse {
     /** Writes the HTTP status message such as "200 OK". */
     writeStatus(status: RecognizedString) : HttpResponse;
     /** Writes key and value to HTTP response. */
@@ -80,7 +80,7 @@ interface HttpResponse {
 }
 
 /** An HttpRequest is stack allocated and only accessible during the callback invocation. */
-interface HttpRequest {
+export interface HttpRequest {
     /** Returns the lowercased header value or empty string. */
     getHeader(lowerCaseKey: RecognizedString) : string;
     /** Returns the parsed parameter at index. Corresponds to route. */
@@ -96,7 +96,7 @@ interface HttpRequest {
 }
 
 /** A structure holding settings and handlers for a WebSocket route handler. */
-interface WebSocketBehavior {
+export interface WebSocketBehavior {
     /** Maximum length of received message. */
     maxPayloadLength?: number;
     /** Maximum amount of seconds that may pass without sending or getting a message. */
@@ -114,7 +114,7 @@ interface WebSocketBehavior {
 }
 
 /** Options used when constructing an app. */
-interface AppOptions {
+export interface AppOptions {
     key_file_name?: RecognizedString;
     cert_file_name?: RecognizedString;
     passphrase?: RecognizedString;
@@ -124,7 +124,7 @@ interface AppOptions {
 }
 
 /** TemplatedApp is either an SSL or non-SSL app. */
-interface TemplatedApp {
+export interface TemplatedApp {
     /** Listens to hostname & port. Callback hands either false or a listen socket. */
     listen(host: RecognizedString, port: number, cb: (listenSocket: us_listen_socket) => void): TemplatedApp;
     /** Listens to port. Callback hands either false or a listen socket. */


### PR DESCRIPTION
Fixing interface TemplatedApp not being able to be imported from: node_modules/uWebSockets.js/index.d.ts

These imports are only used by typescript and would not be in the compiled JavaScript file.

Why upstream typescript wont fix this issue is explained here: https://github.com/Microsoft/TypeScript/issues/24322