### PR TITLE
Better compile output and "make clean"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Ignore dist files
+dist/
+
+# Ignore Temp Files
+headers/
+objects/
+targets/
+
+# Ignore .out
+a.out

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,17 @@
 Windows:
 	$(CC) build.c
 	./a.out || build.exe
+
+clean:
+	rm -rf dist
+	rm -rf headers
+	rm -rf targets
+	rm -rf objects
+	rm -f  *.out
+
+clean-windows:
+	rmdir /S /Q dist
+	rmdir /S /Q headers
+	rmdir /S /Q targets
+	rmdir /S /Q objects
+	del *.out

--- a/build.c
+++ b/build.c
@@ -47,7 +47,7 @@ void prepare() {
 
     /* For all versions */
     for (unsigned int i = 0; i < sizeof(versions) / sizeof(struct node_version); i++) {
-        run("cd headers && curl -OJ https://nodejs.org/dist/%s/node-%s-headers.tar.gz && cd ../", versions[i].name, versions[i].name);
+        run("cd headers ; curl -OJ https://nodejs.org/dist/%s/node-%s-headers.tar.gz ; cd ../", versions[i].name, versions[i].name);
         run("tar xzf headers/node-%s-headers.tar.gz -C targets", versions[i].name);
         run("curl https://nodejs.org/dist/%s/win-x64/node.lib > targets/node-%s/node.lib", versions[i].name, versions[i].name);
     }


### PR DESCRIPTION
I've added a "make clean" and "make clean-windows" to remove build subproducts and dist folders. To do this I changed build.c to save node headers into headers folder and when compiling put .o files on "objects" folder. I did it to improve the development flow, hope that it helps.