### PR TITLE
write 200 status before streaming

### DIFF
--- a/examples/VideoStreamer.js
+++ b/examples/VideoStreamer.js
@@ -101,6 +101,7 @@ const app = uWS./*SSL*/App({
   console.time(res.id = ++streamIndex);
   console.log('Stream was opened, openStreams: ' + ++openStreams);
   /* Create read stream with Node.js and start streaming over Http */
+  res.writeStatus('200');
   const readStream = fs.createReadStream(fileName);
   pipeStreamOverResponse(res, readStream, totalSize);
 }).get('/*', (res, req) => {

--- a/examples/VideoStreamerSync.js
+++ b/examples/VideoStreamerSync.js
@@ -29,6 +29,7 @@ const app = uWS.SSLApp({
   /* Log */
   console.log("Copying Sintel video...");
   /* Copy the entire video to backpressure */
+  res.writeStatus('200');
   res.end(videoFile);
 }).get('/*', (res, req) => {
   /* Make sure to always handle every route */


### PR DESCRIPTION
Hello Alex.

I found obscure behavior while using video streaming example with latest chrome:
if you request stream from html browser rejects request with ERR_INVALID_HTTP_RESPONSE if you are streaming and not writing 200 status immediately. In details:
https://webmasters.stackexchange.com/questions/108292/why-is-chrome-not-allowing-resources-to-load.

 Thank you for this awesome project.

