### PR TITLE
Added bytes concat of the chunks

### DIFF
--- a/examples/Upload.js
+++ b/examples/Upload.js
@@ -13,6 +13,7 @@ const app = uWS./*SSL*/App({
   passphrase: '1234'
 }).post('/*', (res, req) => {
   console.log('Posted to ' + req.getUrl());
+  /* Make sure to handle when this content-length header not presetned or bad value etc */
   const contentLength = +req.getHeader("content-length");
   const bytes = new Uint8Array(contentLength);
   let offset = 0;

--- a/examples/Upload.js
+++ b/examples/Upload.js
@@ -13,13 +13,19 @@ const app = uWS./*SSL*/App({
   passphrase: '1234'
 }).post('/*', (res, req) => {
   console.log('Posted to ' + req.getUrl());
+  const contentLength = +req.getHeader("content-length");
+  const bytes = new Uint8Array(contentLength);
+  let offset = 0;
   res.onData((chunk, isLast) => {
     /* Buffer this anywhere you want to */
     console.log('Got chunk of data with length ' + chunk.byteLength + ', isLast: ' + isLast);
+    bytes.set(new Uint8Array(chunk), offset);
+    offset += chunk.byteLength;
 
     /* We respond when we are done */
     if (isLast) {
       res.end('Thanks for the data!');
+      /* bytes contains the whole file as Uint8Array, you can get the buffer with Buffer.from(bytes)  */
     }
   });
 


### PR DESCRIPTION
Unlike this [JsonPost.js](https://github.com/uNetworking/uWebSockets.js/blob/master/examples/JsonPost.js) example which cause the bytes to look wrong on file ~80KB, this will also create the buffer once.
As for larger file uploads I think streaming to the file system similar to shown in [VideoStreamer.js](https://github.com/uNetworking/uWebSockets.js/blob/master/examples/VideoStreamer.js) would be better.