### PR TITLE
Update TS definitions

### DIFF
--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -191,8 +191,10 @@ export interface HttpRequest {
     getUrl() : string;
     /** Returns the HTTP method, useful for "any" routes. */
     getMethod() : string;
-    /** Returns the part of URL after ? sign or empty string. */
+    /** Returns the raw querystring (the part of URL after ? sign) or empty string. */
     getQuery() : string;
+    /** Returns a decoded query parameter value or empty string. */
+    getQuery(key: string) : string;
     /** Loops over all headers. */
     forEach(cb: (key: string, value: string) => void) : void;
     /** Setting yield to true is to say that this route handler did not handle the route, causing the router to continue looking for a matching route handler, or fail. */
@@ -290,6 +292,16 @@ export function SSLApp(options: AppOptions): TemplatedApp;
 
 /** Closes a uSockets listen socket. */
 export function us_listen_socket_close(listenSocket: us_listen_socket): void;
+
+export interface MultipartField {
+    data: ArrayBuffer;
+    name: string;
+    type?: string;
+    filename?: string;
+}
+
+/** Takes a POSTed body and contentType, and returns an array of parts if the request is a multipart request */
+export function getParts(body: RecognizedString, contentType: RecognizedString): MultipartField[] | undefined;
 
 /** WebSocket compression options */
 export type CompressOptions = number;


### PR DESCRIPTION
Adds TS definition for `getParts` and new overload for `req.getQuery`  added in [v18.7.0](https://github.com/uNetworking/uWebSockets.js/releases/tag/v18.7.0).

I've noticed that previous updates to index.d.ts didn't make it to the `binaries` branch and was thinking about adding it to `copy_files` in build.c, but I also see that you usually copy these files manually so :shrug:

Should I also regenerate HTML docs?