### PR TITLE
fix yarn add

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Runs the trading APIs of [Bitfinex.com](https://bitfinex.com), handling volumes 
 
 ### :package: Easily installed
 
-Install with `yarn add uNetworking/uWebSockets.js#v18.11.0` or any such [release](https://github.com/uNetworking/uWebSockets.js/releases). No compiler needed.
+Install with `yarn add uWebSockets.js@uNetworking/uWebSockets.js#v18.12.0` or any such [release](https://github.com/uNetworking/uWebSockets.js/releases). No compiler needed.
 
 * Runs on Linux, macOS and Windows (ARM64, x64). Node.js 10, 11, 12, 13, 14 & 15.
 * Installs from this GitHub repository, not the NPM registry; [hit "fork" to get your own copy](https://medium.com/@alexhultman/beware-of-tin-foil-hattery-f738b620468c).


### PR DESCRIPTION
```
yarn add uNetworking/uWebSockets.js#v18.12.0

Internal Error: Invalid descriptor (uNetworking/uWebSockets.js#v18.11.0)
    at Module.L (/Users/maxpain/dev/graphql-ws/.yarn/releases/yarn-2.3.3.cjs:2:408950)
    at /Users/maxpain/dev/graphql-ws/.yarn/releases/yarn-2.3.3.cjs:2:25369
    at Array.map (<anonymous>)
    at F.execute (/Users/maxpain/dev/graphql-ws/.yarn/releases/yarn-2.3.3.cjs:2:25265)
    at async F.validateAndExecute (/Users/maxpain/dev/graphql-ws/.yarn/releases/yarn-2.3.3.cjs:2:626801)
    at async j.run (/Users/maxpain/dev/graphql-ws/.yarn/releases/yarn-2.3.3.cjs:17:3854)
    at async j.runExit (/Users/maxpain/dev/graphql-ws/.yarn/releases/yarn-2.3.3.cjs:17:4021)
    at async h (/Users/maxpain/dev/graphql-ws/.yarn/releases/yarn-2.3.3.cjs:2:266144)
    at async r (/Users/maxpain/dev/graphql-ws/.yarn/releases/yarn-2.3.3.cjs:2:264780)
```