### PR TITLE
added ca_file_name to AppOptions

### DIFF
--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -250,6 +250,7 @@ export interface WebSocketBehavior {
 export interface AppOptions {
     key_file_name?: RecognizedString;
     cert_file_name?: RecognizedString;
+    ca_file_name?: RecognizedString;
     passphrase?: RecognizedString;
     dh_params_file_name?: RecognizedString;
     /** This translates to SSL_MODE_RELEASE_BUFFERS */


### PR DESCRIPTION
It is a valid property but is not in the typing. Might save someone some time in the future. 