### PR TITLE
Make idleTimeout a multiple of 4 in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ require('uWebSockets.js').SSLApp({
 }).ws('/*', {
 
   /* There are many common helper features */
-  idleTimeout: 30,
+  idleTimeout: 32,
   maxBackpressure: 1024,
   maxPayloadLength: 512,
   compression: DEDICATED_COMPRESSOR_3KB,


### PR DESCRIPTION
Using the example provided in the README outputs the following warning;

> Warning: idleTimeout should be a multiple of 4!

This PR updates the example according to the warning.