### PR TITLE
Update TypeScript definitions

### DIFF
--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -264,9 +264,9 @@ export enum ListenOptions {
 /** TemplatedApp is either an SSL or non-SSL app. See App for more info, read user manual. */
 export interface TemplatedApp {
     /** Listens to hostname & port. Callback hands either false or a listen socket. */
-    listen(host: RecognizedString, port: number, cb: (listenSocket: us_listen_socket) => void): TemplatedApp;
+    listen(host: RecognizedString, port: number, cb: (listenSocket: us_listen_socket | false) => void): TemplatedApp;
     /** Listens to port. Callback hands either false or a listen socket. */
-    listen(port: number, cb: (listenSocket: any) => void): TemplatedApp;
+    listen(port: number, cb: (listenSocket: us_listen_socket | false) => void): TemplatedApp;
     /** Listens to port and sets Listen Options. Callback hands either false or a listen socket. */
     listen(port: number, options: ListenOptions, cb: (listenSocket: us_listen_socket | false) => void): TemplatedApp;
     /** Registers an HTTP GET handler matching specified URL pattern. */

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -15,7 +15,7 @@
 /** Native type representing a raw uSockets struct us_listen_socket_t.
  * Careful with this one, it is entirely unchecked and native so invalid usage will blow up.
  */
-export interface us_listen_socket {
+export interface us_listen_socket extends us_socket {
 
 }
 

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -222,8 +222,10 @@ export interface WebSocketBehavior {
     idleTimeout?: number;
     /** What permessage-deflate compression to use. uWS.DISABLED, uWS.SHARED_COMPRESSOR or any of the uWS.DEDICATED_COMPRESSOR_xxxKB. Defaults to uWS.DISABLED. */
     compression?: CompressOptions;
-    /** Maximum length of allowed backpressure per socket when publishing or sending messages. Slow receivers with too high backpressure will be skipped until they catch up or timeout. Defaults to 1024 * 1024. */
+    /** Maximum length of allowed backpressure per socket when publishing or sending messages. Slow receivers with too high backpressure will be skipped until they catch up or timeout. Defaults to 64 * 1024. */
     maxBackpressure?: number;
+    /** Whether or not we should automatically close the socket when a message is dropped due to backpressure. Defaults to false. */
+    closeOnBackpressureLimit?: number;
     /** Whether or not we should automatically send pings to uphold a stable connection given whatever idleTimeout. */
     sendPingsAutomatically?: number;
     /** Upgrade handler used to intercept HTTP upgrade requests and potentially upgrade to WebSocket.


### PR DESCRIPTION
Hi there 👋 

Breaking changes:
- Fix `App.listen()` callback parameter type definitions. This is a breaking change if anyone was incorrectly using the types before.

Non-breaking changes:
- Update comment for `maxBackpressure` - default is now 64KB (updated in https://github.com/uNetworking/uWebSockets/commit/20fbdbb7aed6f303caef38eadc1a7ee3aac2e95e)
- Add `closeOnBackpressureLimit` (added in https://github.com/uNetworking/uWebSockets.js/commit/5d6a9c51941ff472a7665549a5de493f8a2618d7)
- Type `us_listen_socket` extends `us_socket` (as per uSocket's [internal.h](https://github.com/uNetworking/uSockets/blob/0128479ed83eb55e18542a96535dd15ef09a3aaf/src/internal/internal.h#L106))

<hr>

Two related notes
1. At the moment `closeOnBackpressureLimit` and `sendPingsAutomatically` are Int32Value in [AppWrapper.h](https://github.com/uNetworking/uWebSockets.js/blob/823e1a9dca337e20344584918969786db8abf2ba/src/AppWrapper.h#L69-L79), should these be BooleanValue?
2. At the moment the native types have compatible interfaces which means that `us_socket_context_t` or any object can be used in places that only accept a `us_listen_socket`. I think that you could do something like this to avoid that happening:
```ts
export interface us_listen_socket extends us_socket {
    _us_listen_socket: never;
}
export interface us_socket {
    _us_socket: never;
}
export interface us_socket_context_t {
    _us_socket_context_t: never;
}
```
This isn't perfect (as users could attempt to use `listenToken._us_listen_socket`), but imo it's an improvement. Do you think this something worth raising an issue for?