### PR TITLE
Remove nodejs 14 from error message

### DIFF
--- a/src/uws.js
+++ b/src/uws.js
@@ -19,6 +19,6 @@ module.exports = (() => {
 	try {
 		return require('./uws_' + process.platform + '_' + process.arch + '_' + process.versions.modules + '.node');
 	} catch (e) {
-		throw new Error('This version of uWS.js supports only Node.js 14, 16 and 18 on (glibc) Linux, macOS and Windows, on Tier 1 platforms (https://github.com/nodejs/node/blob/master/BUILDING.md#platform-list).\n\n' + e.toString());
+		throw new Error('This version of uWS.js supports only Node.js 16 and 18, and 19 on (glibc) Linux, macOS and Windows, on Tier 1 platforms (https://github.com/nodejs/node/blob/master/BUILDING.md#platform-list).\n\n' + e.toString());
 	}
 })();


### PR DESCRIPTION
Nodejs 14 support has been dropped, I have been getting this error on my Nodejs 14 container and I couldn't figure out why. I removed this statement from the error message to prevent further confusion.