### PR TITLE
Arm 32bit support

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -24,7 +24,6 @@ jobs:
           git config --global user.name "Alex Hultman"
           git commit -a -m "[GitHub Actions] Updated windows-latest binaries"
           git push "https://unetworkingab:${{ secrets.SECRET }}@github.com/uNetworking/uWebSockets.js" binaries
-
   build-unix:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -52,11 +51,18 @@ jobs:
 
   build-arm:
     runs-on: ubuntu-latest
-    name: Build on arm64
+    name: Build on ${{ matrix.arch }}
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+            os: ubuntu20.04
+          - arch: armv7
+            os: bullseye
     steps:
       - name: Clone
         run: git clone --recursive https://github.com/uNetworking/uWebSockets.js.git
-      - uses: uraimo/run-on-arch-action@v2.1.1
+      - uses: uraimo/run-on-arch-action@v2.3.0
         name: Compile binaries
         with:
           arch: aarch64
@@ -65,7 +71,7 @@ jobs:
             --volume "${PWD}/uWebSockets.js:/repository"
           install: |
             apt-get update -q -y
-            apt-get install -q -y build-essential cmake libz-dev golang
+            apt-get install -q -y build-essential cmake libz-dev golang curl libunwind-dev
           run: |
             cd /repository
             make
@@ -75,10 +81,12 @@ jobs:
           git fetch origin binaries:binaries
           git checkout binaries
           cp dist/*.node .
+          cp dist/*.js .
           git status
           git rev-parse master > source_commit
           git checkout master docs/index.d.ts && mv docs/index.d.ts .
           git config --global user.email "alexhultman@gmail.com"
           git config --global user.name "Alex Hultman"
+          git add *.node *.js
           git commit -a -m "[GitHub Actions] Updated linux-arm64 binaries" || true
           git push "https://unetworkingab:${{ secrets.SECRET }}@github.com/uNetworking/uWebSockets.js" binaries

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -23,7 +23,7 @@ jobs:
           git config --global user.email "alexhultman@gmail.com"
           git config --global user.name "Alex Hultman"
           git commit -a -m "[GitHub Actions] Updated windows-latest binaries"
-          # git push "https://unetworkingab:${{ secrets.SECRET }}@github.com/uNetworking/uWebSockets.js" binaries
+          git push "https://unetworkingab:${{ secrets.SECRET }}@github.com/uNetworking/uWebSockets.js" binaries
   build-unix:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -47,7 +47,7 @@ jobs:
           git config --global user.email "alexhultman@gmail.com"
           git config --global user.name "Alex Hultman"
           git commit -a -m "[GitHub Actions] Updated ${{ matrix.os }} binaries" || true
-          # git push "https://unetworkingab:${{ secrets.SECRET }}@github.com/uNetworking/uWebSockets.js" binaries
+          git push "https://unetworkingab:${{ secrets.SECRET }}@github.com/uNetworking/uWebSockets.js" binaries
 
   build-arm:
     runs-on: ubuntu-latest
@@ -89,4 +89,4 @@ jobs:
           git config --global user.name "Alex Hultman"
           git add *.node *.js
           git commit -a -m "[GitHub Actions] Updated linux-arm64 binaries" || true
-          # git push "https://unetworkingab:${{ secrets.SECRET }}@github.com/uNetworking/uWebSockets.js" binaries
+          git push "https://unetworkingab:${{ secrets.SECRET }}@github.com/uNetworking/uWebSockets.js" binaries

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -71,7 +71,7 @@ jobs:
             --volume "${PWD}/uWebSockets.js:/repository"
           install: |
             apt-get update -q -y
-            apt-get install -q -y build-essential cmake libz-dev golang curl libunwind-dev
+            apt-get install -q -y build-essential cmake libz-dev golang curl libunwind-dev clang
           run: |
             cd /repository
             make

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ arm-32bit-support ]
+    branches: [ master ]
 
 jobs:
   build-windows:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ arm-32bit-support ]
 
 jobs:
   build-windows:
@@ -23,7 +23,7 @@ jobs:
           git config --global user.email "alexhultman@gmail.com"
           git config --global user.name "Alex Hultman"
           git commit -a -m "[GitHub Actions] Updated windows-latest binaries"
-          git push "https://unetworkingab:${{ secrets.SECRET }}@github.com/uNetworking/uWebSockets.js" binaries
+          # git push "https://unetworkingab:${{ secrets.SECRET }}@github.com/uNetworking/uWebSockets.js" binaries
   build-unix:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -47,7 +47,7 @@ jobs:
           git config --global user.email "alexhultman@gmail.com"
           git config --global user.name "Alex Hultman"
           git commit -a -m "[GitHub Actions] Updated ${{ matrix.os }} binaries" || true
-          git push "https://unetworkingab:${{ secrets.SECRET }}@github.com/uNetworking/uWebSockets.js" binaries
+          # git push "https://unetworkingab:${{ secrets.SECRET }}@github.com/uNetworking/uWebSockets.js" binaries
 
   build-arm:
     runs-on: ubuntu-latest
@@ -89,4 +89,4 @@ jobs:
           git config --global user.name "Alex Hultman"
           git add *.node *.js
           git commit -a -m "[GitHub Actions] Updated linux-arm64 binaries" || true
-          git push "https://unetworkingab:${{ secrets.SECRET }}@github.com/uNetworking/uWebSockets.js" binaries
+          # git push "https://unetworkingab:${{ secrets.SECRET }}@github.com/uNetworking/uWebSockets.js" binaries

--- a/build.c
+++ b/build.c
@@ -131,7 +131,7 @@ int main() {
     arch = ARM64;
 #endif
 #ifdef __arm__
-    arch = ARM
+    arch = ARM;
 #endif
     
     /* Build for x64 and/or arm64 */

--- a/build.c
+++ b/build.c
@@ -17,6 +17,7 @@
 #define IS_MACOS
 #endif
 
+const char *ARM = "arm";
 const char *ARM64 = "arm64";
 const char *X64 = "x64";
 
@@ -128,6 +129,9 @@ int main() {
     const char *arch = X64;
 #ifdef __aarch64__
     arch = ARM64;
+#endif
+#ifdef __arm__
+    arch = ARM
 #endif
     
     /* Build for x64 and/or arm64 */

--- a/build.c
+++ b/build.c
@@ -127,13 +127,12 @@ int main() {
     printf("\n[Building]\n");
     
     const char *arch = X64;
-#ifdef __aarch64__
-    arch = ARM64;
-#endif
 #ifdef __arm__
     arch = ARM;
 #endif
-    
+#ifdef __aarch64__
+    arch = ARM64;
+#endif
     /* Build for x64 and/or arm64 */
     build_boringssl(arch);
 

--- a/build.c
+++ b/build.c
@@ -58,7 +58,7 @@ void prepare() {
 
 void build_lsquic(const char *arch) {
 #ifndef IS_WINDOWS
-    /* Build for x64 or arm64 (depending on the host) */
+    /* Build for x64 or arm/arm64 (depending on the host) */
     run("cd uWebSockets/uSockets/lsquic && cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBORINGSSL_DIR=../boringssl -DCMAKE_BUILD_TYPE=Release -DLSQUIC_BIN=Off . && make lsquic");
 #else
     run("cd uWebSockets/uSockets/lsquic && cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBORINGSSL_DIR=../boringssl -DCMAKE_BUILD_TYPE=Release -DLSQUIC_BIN=Off . && msbuild ALL_BUILD.vcxproj");
@@ -77,7 +77,7 @@ void build_boringssl(const char *arch) {
 #endif
     
 #ifdef IS_LINUX
-    /* Build for x64 or arm64 (depending on the host) */
+    /* Build for x64 or arm/arm64 (depending on the host) */
     run("cd uWebSockets/uSockets/boringssl && mkdir -p %s && cd %s && cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_BUILD_TYPE=Release .. && make crypto ssl", arch, arch);
 #endif
     
@@ -133,7 +133,7 @@ int main() {
 #ifdef __aarch64__
     arch = ARM64;
 #endif
-    /* Build for x64 and/or arm64 */
+    /* Build for x64 and/or arm/arm64 */
     build_boringssl(arch);
 
     build_lsquic(arch);


### PR DESCRIPTION
Hi,

First of all, thanks for this great project and for sharing your commendable talent and skills to the open source community.

As I've mentioned before in my previous PR about submitting 32bit binaries for ARM, I've figured out how to generate binaries automatically using your github actions script. Right now it is able to build for `armv7` architecture. Although you've mentioned that you won't support 32-bit arm, I hope you can include this build script so that other people that need this can use your library without having to fork it. 

In my use case, I am using [hyper-express](https://github.com/kartikk221/hyper-express) (express-like library on top of `uWebSockets.js`). Without 32-bit support from uWebSockets.js, I will have to fork both `hyper-express` and `uWebSockets.js` which adds a bit of friction when trying to keep up with the latest releases from both package. I hope you can consider merging this PR.