### PR TITLE
Add TypeScript definitions for `endWithoutBody`

### DIFF
--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -140,6 +140,8 @@ export interface HttpResponse {
     write(chunk: RecognizedString) : boolean;
     /** Ends this response by copying the contents of body. */
     end(body?: RecognizedString, closeConnection?: boolean) : HttpResponse;
+    /** Ends this response without a body. */
+    endWithoutBody(reportedContentLength?: number, closeConnection?: boolean) : HttpResponse;
     /** Ends this response, or tries to, by streaming appropriately sized chunks of body. Use in conjunction with onWritable. Returns tuple [ok, hasResponded].*/
     tryEnd(fullBodyOrChunk: RecognizedString, totalSize: number) : [boolean, boolean];
 


### PR DESCRIPTION
Hey there 👋 

This adds TypeScript definitions for the `res.endWithoutBody(number, bool)` method, which was exposed in 63c9759d661bc5fbc69a4b018a087d2478b898f2.