### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "uWebSockets.js",
   "version": "20.31.0",
+  "license": "Apache-2.0",
   "main": "uws.js",
   "types": "./index.d.ts",
   "exports": {


### PR DESCRIPTION
We use [davglass/license-checker](https://github.com/davglass/license-checker) to audit the licenses of our dependencies. uWebSockets.js is being flagged because it doesn't define a license in its package.json.