### PR TITLE
add typing for TemplatedApp.close()

### DIFF
--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -325,6 +325,8 @@ export interface TemplatedApp {
     removeServerName(hostname: string) : TemplatedApp;
     /** Registers a synchronous callback on missing server names. See /examples/ServerName.js. */
     missingServerName(cb: (hostname: string) => void) : TemplatedApp;
+    /** Closes all sockets including listen sockets. This will forcefully terminate all connections. */
+    close() : TemplatedApp;
 }
 
 /** Constructs a non-SSL app. An app is your starting point where you attach behavior to URL routes.


### PR DESCRIPTION
Thanks for this great library!

Noticed the c++ repo had a [close method](https://github.com/uNetworking/uWebSockets/blob/master/src/App.h#L252C5-L260), so adding it to the typings.