### PR TITLE
Add binding for App.filter

### DIFF
--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -325,6 +325,8 @@ export interface TemplatedApp {
     removeServerName(hostname: string) : TemplatedApp;
     /** Registers a synchronous callback on missing server names. See /examples/ServerName.js. */
     missingServerName(cb: (hostname: string) => void) : TemplatedApp;
+    /** Attaches a "filter" function to track socket connections / disconnections */
+    filter(cb: (res: HttpResponse, count: Number) => void | Promise<void>) : TemplatedApp;
     /** Closes all sockets including listen sockets. This will forcefully terminate all connections. */
     close() : TemplatedApp;
 }


### PR DESCRIPTION
Hi,

In my javascript application I need to keep track of the number of open connections. I found that the C++ library already has the filter function for that, so I added a wrapper for it.

I tried to follow the examples of the other wrappers as much as possible, and also added a brief documentation. Could you review and consider integrating this change in the master branch?

Thanks in advance,

Dries De Winter.