### PR TITLE
Update getParameter example to use index instead of name

### DIFF
--- a/examples/Benchmarker.js
+++ b/examples/Benchmarker.js
@@ -7,7 +7,7 @@ require('uWebSockets.js')
 	.get('/id/:id', (res, req) => {
 		res.writeHeader('content-type', 'text/plain')
 			.writeHeader('x-powered-by', 'benchmark')
-			.end(`${req.getParameter('id')} ${req.getQuery('name')}`)
+			.end(`${req.getParameter(0)} ${req.getQuery('name')}`)
 	})
 	.post('/json', (res, req) => {
 		readJson(


### PR DESCRIPTION
This PR updates the `Benchmarker.js` to use the most recent signature for `HTTPRequest::getParameter`, which accepts the index of the parameter instead of the name. The `Router.js` example already has the appropriate change, but this example is outdated.