### PR TITLE
feat: expose client's peer certificate der data

### DIFF
--- a/examples/PeerCertificate.js
+++ b/examples/PeerCertificate.js
@@ -1,0 +1,138 @@
+const https = require('https');
+const forge = require('node-forge');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+// Generate CA certificate
+const ca = generateCACertificate();
+const caCertPem = pemEncodeCert(ca.cert);
+
+// Generate server certificate signed by CA
+const serverCert = generateCertificate(ca, 'localhost');
+const serverCertPem = pemEncodeCert(serverCert.cert);
+const serverKeyPem = pemEncodeKey(serverCert.privateKey);
+
+// Generate client certificate signed by CA
+const clientCert = generateCertificate(ca, 'client');
+const clientCertPem = pemEncodeCert(clientCert.cert);
+const clientKeyPem = pemEncodeKey(clientCert.privateKey);
+
+fs.writeFileSync(path.join(__dirname, "server.ca"), caCertPem);
+fs.writeFileSync(path.join(__dirname, "server.key"), serverKeyPem);
+fs.writeFileSync(path.join(__dirname, "server.cert"), serverCertPem);
+
+const uWS = require('../dist/uws');
+const port = 8086;
+
+const app = uWS.SSLApp({
+    cert_file_name: path.join(__dirname, "server.cert"),
+    key_file_name: path.join(__dirname, "server.key"),
+    ca_file_name: path.join(__dirname, "server.ca")
+}).get('/*', (res, req) => {
+    const certInfo = res.getPeerCertificate();
+    console.log(certInfo)
+    const certDataBuffer = Buffer.from(certInfo.raw).toString('base64');
+    const binaryDerCertificate = forge.util.decode64(certDataBuffer);
+    const cert = forge.pki.certificateFromAsn1(forge.asn1.fromDer(binaryDerCertificate));
+    const pemCertificate = forge.pki.certificateToPem(cert);
+    if (new crypto.X509Certificate(pemCertificate).verify(crypto.createPublicKey(caCertPem))) {
+        res.end(`Hello World! your certificate is valid!`);
+    }
+    else
+        res.end('Hello World!');
+
+}).listen(port, (token) => {
+    if (token) {
+        console.log('Listening to port ' + port);
+        sendClientRequest();
+    } else {
+        console.log('Failed to listen to port ' + port);
+    }
+});
+
+function generateCACertificate() {
+    const keys = forge.pki.rsa.generateKeyPair(2048);
+    const cert = forge.pki.createCertificate();
+    cert.publicKey = keys.publicKey;
+    cert.serialNumber = '01';
+    cert.validity.notBefore = new Date();
+    cert.validity.notAfter = new Date();
+    cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1);
+    const attrs = [
+        { name: 'commonName', value: 'example.org' },
+        { name: 'countryName', value: 'US' },
+        { shortName: 'ST', value: 'California' },
+        { name: 'localityName', value: 'San Francisco' },
+        { name: 'organizationName', value: 'example.org' },
+        { shortName: 'OU', value: 'Test' }
+    ];
+    cert.setSubject(attrs);
+    cert.setIssuer(attrs);
+    cert.setExtensions([{
+        name: 'basicConstraints',
+        cA: true
+    }]);
+    cert.sign(keys.privateKey, forge.md.sha256.create());
+    return {
+        privateKey: keys.privateKey,
+        publicKey: keys.publicKey,
+        cert: cert
+    };
+}
+
+function generateCertificate(ca, commonName) {
+    const keys = forge.pki.rsa.generateKeyPair(2048);
+    const cert = forge.pki.createCertificate();
+    cert.publicKey = keys.publicKey;
+    cert.serialNumber = '02';
+    cert.validity.notBefore = new Date();
+    cert.validity.notAfter = new Date();
+    cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1);
+    const attrs = [
+        { name: 'commonName', value: commonName }
+    ];
+    cert.setSubject(attrs);
+    cert.setIssuer(ca.cert.subject.attributes);
+    cert.sign(ca.privateKey, forge.md.sha256.create());
+    return {
+        privateKey: keys.privateKey,
+        cert: cert
+    };
+}
+
+function pemEncodeCert(cert) {
+    return forge.pki.certificateToPem(cert);
+}
+
+function pemEncodeKey(key) {
+    return forge.pki.privateKeyToPem(key);
+}
+
+function sendClientRequest() {
+    const clientOptions = {
+        hostname: 'localhost',
+        port: port,
+        path: '/',
+        method: 'GET',
+        key: clientKeyPem,
+        cert: clientCertPem,
+        ca: [caCertPem],
+        rejectUnauthorized: false
+    };
+
+    const req = https.request(clientOptions, (res) => {
+        let data = '';
+        res.on('data', (chunk) => {
+            data += chunk;
+        });
+        res.on('end', () => {
+            console.log('Response from server:', data);
+        });
+    });
+
+    req.on('error', (e) => {
+        console.error('errp', e);
+    });
+
+    req.end();
+}

--- a/examples/PeerCertificate.js
+++ b/examples/PeerCertificate.js
@@ -29,13 +29,9 @@ const app = uWS.SSLApp({
   key_file_name: path.join(__dirname, "server.key"),
   ca_file_name: path.join(__dirname, "server.ca")
 }).get('/*', (res, req) => {
-  const certInfo = res.getPeerCertificate();
-  console.log(certInfo)
-  const certDataBuffer = Buffer.from(certInfo.raw).toString('base64');
-  const binaryDerCertificate = forge.util.decode64(certDataBuffer);
-  const cert = forge.pki.certificateFromAsn1(forge.asn1.fromDer(binaryDerCertificate));
-  const pemCertificate = forge.pki.certificateToPem(cert);
-  if (new crypto.X509Certificate(pemCertificate).verify(crypto.createPublicKey(caCertPem))) {
+  const clientCert = res.getX509Certificate();
+  const x509 = new crypto.X509Certificate(clientCert);
+  if (x509.verify(crypto.createPublicKey(caCertPem))) {
     res.end(`Hello World! your certificate is valid!`);
   }
   else

--- a/examples/PeerCertificate.js
+++ b/examples/PeerCertificate.js
@@ -25,114 +25,114 @@ const uWS = require('../dist/uws');
 const port = 8086;
 
 const app = uWS.SSLApp({
-    cert_file_name: path.join(__dirname, "server.cert"),
-    key_file_name: path.join(__dirname, "server.key"),
-    ca_file_name: path.join(__dirname, "server.ca")
+  cert_file_name: path.join(__dirname, "server.cert"),
+  key_file_name: path.join(__dirname, "server.key"),
+  ca_file_name: path.join(__dirname, "server.ca")
 }).get('/*', (res, req) => {
-    const certInfo = res.getPeerCertificate();
-    console.log(certInfo)
-    const certDataBuffer = Buffer.from(certInfo.raw).toString('base64');
-    const binaryDerCertificate = forge.util.decode64(certDataBuffer);
-    const cert = forge.pki.certificateFromAsn1(forge.asn1.fromDer(binaryDerCertificate));
-    const pemCertificate = forge.pki.certificateToPem(cert);
-    if (new crypto.X509Certificate(pemCertificate).verify(crypto.createPublicKey(caCertPem))) {
-        res.end(`Hello World! your certificate is valid!`);
-    }
-    else
-        res.end('Hello World!');
+  const certInfo = res.getPeerCertificate();
+  console.log(certInfo)
+  const certDataBuffer = Buffer.from(certInfo.raw).toString('base64');
+  const binaryDerCertificate = forge.util.decode64(certDataBuffer);
+  const cert = forge.pki.certificateFromAsn1(forge.asn1.fromDer(binaryDerCertificate));
+  const pemCertificate = forge.pki.certificateToPem(cert);
+  if (new crypto.X509Certificate(pemCertificate).verify(crypto.createPublicKey(caCertPem))) {
+    res.end(`Hello World! your certificate is valid!`);
+  }
+  else
+    res.end('Hello World!');
 
 }).listen(port, (token) => {
-    if (token) {
-        console.log('Listening to port ' + port);
-        sendClientRequest();
-    } else {
-        console.log('Failed to listen to port ' + port);
-    }
+  if (token) {
+    console.log('Listening to port ' + port);
+    sendClientRequest();
+  } else {
+    console.log('Failed to listen to port ' + port);
+  }
 });
 
 function generateCACertificate() {
-    const keys = forge.pki.rsa.generateKeyPair(2048);
-    const cert = forge.pki.createCertificate();
-    cert.publicKey = keys.publicKey;
-    cert.serialNumber = '01';
-    cert.validity.notBefore = new Date();
-    cert.validity.notAfter = new Date();
-    cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1);
-    const attrs = [
-        { name: 'commonName', value: 'example.org' },
-        { name: 'countryName', value: 'US' },
-        { shortName: 'ST', value: 'California' },
-        { name: 'localityName', value: 'San Francisco' },
-        { name: 'organizationName', value: 'example.org' },
-        { shortName: 'OU', value: 'Test' }
-    ];
-    cert.setSubject(attrs);
-    cert.setIssuer(attrs);
-    cert.setExtensions([{
-        name: 'basicConstraints',
-        cA: true
-    }]);
-    cert.sign(keys.privateKey, forge.md.sha256.create());
-    return {
-        privateKey: keys.privateKey,
-        publicKey: keys.publicKey,
-        cert: cert
-    };
+  const keys = forge.pki.rsa.generateKeyPair(2048);
+  const cert = forge.pki.createCertificate();
+  cert.publicKey = keys.publicKey;
+  cert.serialNumber = '01';
+  cert.validity.notBefore = new Date();
+  cert.validity.notAfter = new Date();
+  cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1);
+  const attrs = [
+    { name: 'commonName', value: 'example.org' },
+    { name: 'countryName', value: 'US' },
+    { shortName: 'ST', value: 'California' },
+    { name: 'localityName', value: 'San Francisco' },
+    { name: 'organizationName', value: 'example.org' },
+    { shortName: 'OU', value: 'Test' }
+  ];
+  cert.setSubject(attrs);
+  cert.setIssuer(attrs);
+  cert.setExtensions([{
+    name: 'basicConstraints',
+    cA: true
+  }]);
+  cert.sign(keys.privateKey, forge.md.sha256.create());
+  return {
+    privateKey: keys.privateKey,
+    publicKey: keys.publicKey,
+    cert: cert
+  };
 }
 
 function generateCertificate(ca, commonName) {
-    const keys = forge.pki.rsa.generateKeyPair(2048);
-    const cert = forge.pki.createCertificate();
-    cert.publicKey = keys.publicKey;
-    cert.serialNumber = '02';
-    cert.validity.notBefore = new Date();
-    cert.validity.notAfter = new Date();
-    cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1);
-    const attrs = [
-        { name: 'commonName', value: commonName }
-    ];
-    cert.setSubject(attrs);
-    cert.setIssuer(ca.cert.subject.attributes);
-    cert.sign(ca.privateKey, forge.md.sha256.create());
-    return {
-        privateKey: keys.privateKey,
-        cert: cert
-    };
+  const keys = forge.pki.rsa.generateKeyPair(2048);
+  const cert = forge.pki.createCertificate();
+  cert.publicKey = keys.publicKey;
+  cert.serialNumber = '02';
+  cert.validity.notBefore = new Date();
+  cert.validity.notAfter = new Date();
+  cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1);
+  const attrs = [
+    { name: 'commonName', value: commonName }
+  ];
+  cert.setSubject(attrs);
+  cert.setIssuer(ca.cert.subject.attributes);
+  cert.sign(ca.privateKey, forge.md.sha256.create());
+  return {
+    privateKey: keys.privateKey,
+    cert: cert
+  };
 }
 
 function pemEncodeCert(cert) {
-    return forge.pki.certificateToPem(cert);
+  return forge.pki.certificateToPem(cert);
 }
 
 function pemEncodeKey(key) {
-    return forge.pki.privateKeyToPem(key);
+  return forge.pki.privateKeyToPem(key);
 }
 
 function sendClientRequest() {
-    const clientOptions = {
-        hostname: 'localhost',
-        port: port,
-        path: '/',
-        method: 'GET',
-        key: clientKeyPem,
-        cert: clientCertPem,
-        ca: [caCertPem],
-        rejectUnauthorized: false
-    };
+  const clientOptions = {
+    hostname: 'localhost',
+    port: port,
+    path: '/',
+    method: 'GET',
+    key: clientKeyPem,
+    cert: clientCertPem,
+    ca: [caCertPem],
+    rejectUnauthorized: false
+  };
 
-    const req = https.request(clientOptions, (res) => {
-        let data = '';
-        res.on('data', (chunk) => {
-            data += chunk;
-        });
-        res.on('end', () => {
-            console.log('Response from server:', data);
-        });
+  const req = https.request(clientOptions, (res) => {
+    let data = '';
+    res.on('data', (chunk) => {
+      data += chunk;
     });
-
-    req.on('error', (e) => {
-        console.error('errp', e);
+    res.on('end', () => {
+      console.log('Response from server:', data);
     });
+  });
 
-    req.end();
+  req.on('error', (e) => {
+    console.error('errp', e);
+  });
+
+  req.end();
 }

--- a/src/HttpResponseWrapper.h
+++ b/src/HttpResponseWrapper.h
@@ -179,16 +179,15 @@ struct HttpResponseWrapper {
         }
     }
 
-    /* Takes nothing, returns arraybuffer */
     template <int PROTOCOL>
-    static void res_getPeerCertificate(const FunctionCallbackInfo<Value> &args) {
+    static void res_getX509Certificate(const FunctionCallbackInfo<Value> &args) {
         Isolate *isolate = args.GetIsolate();
         auto *res = getHttpResponse<PROTOCOL>(args);
         if (res) {
             void* sslHandle = res->getNativeHandle();
             SSL* ssl = static_cast<SSL*>(sslHandle);
-            Local<Object> certInfo = extractCertificateInfo(isolate, ssl);
-            args.GetReturnValue().Set(certInfo);
+            std::string x509cert = extractX509PemCertificate(ssl);
+            args.GetReturnValue().Set(String::NewFromUtf8(isolate, x509cert.c_str(), NewStringType::kNormal).ToLocalChecked());
         }
     }
 
@@ -469,7 +468,7 @@ struct HttpResponseWrapper {
         }
 
         if constexpr (SSL == 1) {
-            resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getPeerCertificate", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_getPeerCertificate<SSL>));
+            resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getX509Certificate", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_getX509Certificate<SSL>));
         }
         
         /* Create our template */

--- a/src/Utilities.h
+++ b/src/Utilities.h
@@ -188,12 +188,14 @@ std::string extractX509PemCertificate(SSL* ssl) {
 
     // Convert X509 certificate to PEM format
     BIO* bio = BIO_new(BIO_s_mem());
-    if (PEM_write_bio_X509(bio, peerCertificate)) {
-        char* buffer;
-        long length = BIO_get_mem_data(bio, &buffer);
-        pemCertificate.assign(buffer, length);
+    if(bio) {
+        if (PEM_write_bio_X509(bio, peerCertificate)) {
+            char* buffer;
+            long length = BIO_get_mem_data(bio, &buffer);
+            pemCertificate.assign(buffer, length);
+        }
+        BIO_free(bio);
     }
-    BIO_free(bio);
 
     // Free the peer certificate
     X509_free(peerCertificate);


### PR DESCRIPTION
This PR implements #1058 and adds access to the client's peer DER certificate data. 
The function returns an object with a "raw" field in it. So if anyone else wants to expand the information returned about the certificate in the future, they can simply append a new key to the object.

Note: I'm not super familiar with C++, so I hope I got everything right. Please go easy on me with the review 😅