### PR TITLE
Add missing listen type

### DIFF
--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -287,6 +287,8 @@ export enum ListenOptions {
 export interface TemplatedApp {
     /** Listens to hostname & port. Callback hands either false or a listen socket. */
     listen(host: RecognizedString, port: number, cb: (listenSocket: us_listen_socket | false) => void | Promise<void>) : TemplatedApp;
+    /** Listens to hostname & port and sets Listen Options. Callback hands either false or a listen socket. */
+    listen(host: RecognizedString, port: number, options: ListenOptions, cb: (listenSocket: us_listen_socket | false) => void | Promise<void>) : TemplatedApp;
     /** Listens to port. Callback hands either false or a listen socket. */
     listen(port: number, cb: (listenSocket: us_listen_socket | false) => void | Promise<void>) : TemplatedApp;
     /** Listens to port and sets Listen Options. Callback hands either false or a listen socket. */


### PR DESCRIPTION
based on https://github.com/uNetworking/uWebSockets.js/issues/118#issuecomment-2479623814 and code from uWebSockets code :
https://github.com/uNetworking/uWebSockets/blob/02610f421f90697c92acc561ec350d5ee3f3235c/src/App.h#L553-L560

listen with host, port, options and callback args is missing from index.d.ts