### PR TITLE
Add getRemotePort bindings

### DIFF
--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -104,6 +104,9 @@ export interface WebSocket<UserData> {
     /** Returns the remote IP address as text. See RecognizedString. */
     getRemoteAddressAsText() : ArrayBuffer;
 
+    /** Returns the remote port number. */
+    getRemotePort() : number;
+
     /** Returns the UserData object. */
     getUserData() : UserData;
 }
@@ -172,11 +175,17 @@ export interface HttpResponse {
     /** Returns the remote IP address as text. */
     getRemoteAddressAsText() : ArrayBuffer;
 
+    /** Returns the remote port number. */
+    getRemotePort() : number;
+
     /** Returns the remote IP address in binary format (4 or 16 bytes), as reported by the PROXY Protocol v2 compatible proxy. */
     getProxiedRemoteAddress() : ArrayBuffer;
 
     /** Returns the remote IP address as text, as reported by the PROXY Protocol v2 compatible proxy. */
     getProxiedRemoteAddressAsText() : ArrayBuffer;
+
+    /** Returns the remote port number, as reported by the PROXY Protocol v2 compatible proxy. */
+    getProxiedRemotePort() : number;
 
     /** Corking a response is a performance improvement in both CPU and network, as you ready the IO system for writing multiple chunks at once.
      * By default, you're corked in the immediately executing top portion of the route handler. In all other cases, such as when returning from

--- a/src/HttpResponseWrapper.h
+++ b/src/HttpResponseWrapper.h
@@ -160,6 +160,18 @@ struct HttpResponseWrapper {
         }
     }
 
+    /* Takes nothing, returns integer */
+    template <int SSL>
+    static void res_getRemotePort(const FunctionCallbackInfo<Value> &args) {
+        Isolate *isolate = args.GetIsolate();
+        auto *res = getHttpResponse<SSL>(args);
+        if (res) {
+            unsigned int port = res->getRemotePort();
+
+            args.GetReturnValue().Set(Integer::NewFromUnsigned(isolate, port));
+        }
+    }
+
     /* Takes nothing, returns arraybuffer */
     template <int SSL>
     static void res_getProxiedRemoteAddress(const FunctionCallbackInfo<Value> &args) {
@@ -181,6 +193,18 @@ struct HttpResponseWrapper {
             std::string_view ip = res->getProxiedRemoteAddressAsText();
 
             args.GetReturnValue().Set(ArrayBuffer_NewCopy(isolate, (void *) ip.data(), ip.length()));
+        }
+    }
+
+    /* Takes nothing, returns number */
+    template <int SSL>
+    static void res_getProxiedRemotePort(const FunctionCallbackInfo<Value> &args) {
+        Isolate *isolate = args.GetIsolate();
+        auto *res = getHttpResponse<SSL>(args);
+        if (res) {
+            unsigned int port = res->getProxiedRemotePort();
+
+            args.GetReturnValue().Set(Integer::NewFromUnsigned(isolate, port));
         }
     }
 
@@ -472,8 +496,10 @@ struct HttpResponseWrapper {
                 resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "collect", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_cork<SSL>));
                 resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "upgrade", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_upgrade<SSL>));
                 resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getRemoteAddressAsText", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_getRemoteAddressAsText<SSL>));
+                resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getRemotePort", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_getRemotePort<SSL>));
                 resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getProxiedRemoteAddress", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_getProxiedRemoteAddress<SSL>));
                 resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getProxiedRemoteAddressAsText", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_getProxiedRemoteAddressAsText<SSL>));
+                resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getProxiedRemotePort", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_getProxiedRemotePort<SSL>));
                 resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "pause", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_pause<SSL>));
                 resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "resume", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_resume<SSL>));
             }

--- a/src/WebSocketWrapper.h
+++ b/src/WebSocketWrapper.h
@@ -161,6 +161,17 @@ struct WebSocketWrapper {
 
     /* Takes nothing, returns integer */
     template <bool SSL>
+    static void uWS_WebSocket_getRemotePort(const FunctionCallbackInfo<Value> &args) {
+        Isolate *isolate = args.GetIsolate();
+        auto *ws = getWebSocket<SSL>(args);
+        if (ws) {
+            unsigned int port = ws->getRemotePort();
+            args.GetReturnValue().Set(Integer::NewFromUnsigned(isolate, port));
+        }
+    }
+
+    /* Takes nothing, returns integer */
+    template <bool SSL>
     static void uWS_WebSocket_getBufferedAmount(const FunctionCallbackInfo<Value> &args) {
         Isolate *isolate = args.GetIsolate();
         auto *ws = getWebSocket<SSL>(args);
@@ -335,6 +346,7 @@ struct WebSocketWrapper {
         wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "cork", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_cork<SSL>));
         wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "ping", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_ping<SSL>));
         wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getRemoteAddressAsText", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_getRemoteAddressAsText<SSL>));
+        wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getRemotePort", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_getRemotePort<SSL>));
         wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "isSubscribed", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_isSubscribed<SSL>));
 
         /* This one does not exist in C++ */


### PR DESCRIPTION
Adds binding for getRemotePort, requires first merging pull request:
https://github.com/uNetworking/uWebSockets/pull/1854

Related to issue: https://github.com/uNetworking/uWebSockets.js/issues/1160