### PR TITLE
expose ssl cipher to node

### DIFF
--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -178,6 +178,9 @@ export interface HttpResponse {
     /** Returns the remote IP address as text, as reported by the PROXY Protocol v2 compatible proxy. */
     getProxiedRemoteAddressAsText() : ArrayBuffer;
 
+    /** Returns the SSL cipher used for connection */
+    getSSLCipher(): string
+
     /** Corking a response is a performance improvement in both CPU and network, as you ready the IO system for writing multiple chunks at once.
      * By default, you're corked in the immediately executing top portion of the route handler. In all other cases, such as when returning from
      * await, or when being called back from an async database request or anything that isn't directly executing in the route handler, you'll want

--- a/src/HttpResponseWrapper.h
+++ b/src/HttpResponseWrapper.h
@@ -196,6 +196,18 @@ struct HttpResponseWrapper {
         }
     }
 
+    template <int PROTOCOL>
+    static void res_getSSLCipher(const FunctionCallbackInfo<Value> &args) {
+        Isolate *isolate = args.GetIsolate();
+        auto *res = getHttpResponse<PROTOCOL>(args);
+        if (res) {
+            void* sslHandle = res->getNativeHandle();
+            SSL* ssl = static_cast<SSL*>(sslHandle);
+            std::string ciphers = getSSLCipher(ssl);
+            args.GetReturnValue().Set(String::NewFromUtf8(isolate, ciphers.c_str(), NewStringType::kNormal).ToLocalChecked());
+        }
+    }
+
     /* Returns the current write offset */
     template <int SSL>
     static void res_getWriteOffset(const FunctionCallbackInfo<Value> &args) {
@@ -481,6 +493,7 @@ struct HttpResponseWrapper {
 
         if constexpr (SSL == 1) {
             resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getX509Certificate", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_getX509Certificate<SSL>));
+            resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getSSLCipher", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_getSSLCipher<SSL>));
         }
         
         /* Create our template */

--- a/src/Utilities.h
+++ b/src/Utilities.h
@@ -202,4 +202,19 @@ std::string extractX509PemCertificate(SSL* ssl) {
     return pemCertificate;
 }
 
+std::string getSSLCipher(SSL* ssl) {
+    std::string cipher;
+    if (!ssl) {
+        return cipher;
+    }
+    const SSL_CIPHER *peerCipher = SSL_get_current_cipher(ssl);
+    if (!peerCipher) {
+        return cipher;
+    }
+    const char *cipher_name = SSL_CIPHER_get_name(peerCipher);
+    cipher = std::string(cipher_name);
+    return cipher;
+}
+
+
 #endif


### PR DESCRIPTION
i need to know which cipher schemes are used by clients to estimate how many will be dropped if i update an ssl_ciphers to use only modern ones