### PR TITLE
Update end method to handle string and Uint8Array

### DIFF
--- a/uws.js
+++ b/uws.js
@@ -52,8 +52,8 @@ module.exports.DeclarativeResponse = class DeclarativeResponse {
   write(value) { return this._appendInstructionWithLength(5, value), this; }
   writeParameterValue(key) { return this._appendInstruction(6, key), this; }
 
-  end(value) {
-    const bytes = new TextEncoder().encode(value);
+  end(str) {
+    const bytes = (typeof str === 'string') ? new TextEncoder().encode(str) : str;
     const length = bytes.length;
     this.instructions.push(0, length & 0xff, (length >> 8) & 0xff, ...bytes);
     return new Uint8Array(this.instructions).buffer;


### PR DESCRIPTION
Currently, the `end` method of DeclarativeResponse only supports `String`, not `ArrayBuffer` or `TypedArray`. This PR uses the same one-line logic as the `_appendInstruction` to use `TextEncoder().encode` only for the string case, letting the other cases pass through as-is.