### PR TITLE
Update DeclarativeResponse: add writeStatus support

### DIFF
--- a/src/AppWrapper.h
+++ b/src/AppWrapper.h
@@ -413,6 +413,18 @@ void uWS_App_get(F f, const FunctionCallbackInfo<Value> &args) {
                             res->write(req->getParameter(keyString));
                         }
                         break;
+                        case 7: {
+                            /* opCode WRITE_STATUS */
+                            uint8_t statusLength;
+                            memcpy(&statusLength, remainingInstructions.data() + 1, 1);
+                            remainingInstructions.remove_prefix(2); // Skip opCode and status length bytes
+                            
+                            std::string_view statusString(remainingInstructions.data(), statusLength);
+                            remainingInstructions.remove_prefix(statusLength);
+
+                            res->writeStatus(statusString);
+                        }
+                        break;
                     }
                 }
 

--- a/src/uws.js
+++ b/src/uws.js
@@ -51,6 +51,7 @@ module.exports.DeclarativeResponse = class DeclarativeResponse {
   writeHeaderValue(key) { return this._appendInstruction(4, key), this; }
   write(value) { return this._appendInstructionWithLength(5, value), this; }
   writeParameterValue(key) { return this._appendInstruction(6, key), this; }
+  writeStatus(status) { return this._appendInstruction(7, status), this; }
 
   end(str) {
     const bytes = (typeof str === 'string') ? new TextEncoder().encode(str) : str;


### PR DESCRIPTION
This adds support for DeclarativeResponse.writeStatus(status) function.
I didn't test as I can't recompile but it should just work.