### PR TITLE
Doc: us_socket_local_port() also accepts us_listen_socket type

### DIFF
--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -362,7 +362,7 @@ export function SSLApp(options: AppOptions) : TemplatedApp;
 export function us_listen_socket_close(listenSocket: us_listen_socket) : void;
 
 /** Gets local port of socket (or listenSocket) or -1. */
-export function us_socket_local_port(socket: us_socket) : number;
+export function us_socket_local_port(socket: us_socket | us_listen_socket) : number;
 
 export interface MultipartField {
     data: ArrayBuffer;


### PR DESCRIPTION
us_socket_local_port() doc was only accepting us_socket, while we can also use us_listen_socket.