### PR TITLE
Update onData() documentation

### DIFF
--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -140,13 +140,6 @@ export interface HttpResponse {
      * the user manual under "corking".
     */
     writeStatus(status: RecognizedString) : HttpResponse;
-
-    /** Pause http body streaming (throttle) */
-    pause() : void;
-
-    /** Resume http body streaming (unthrottle) */
-    resume() : void;
-
     /** Writes key and value to HTTP response.
      * See writeStatus and corking.
     */
@@ -178,8 +171,15 @@ export interface HttpResponse {
      * When this event emits, the response has been aborted and may not be used. */
     onAborted(handler: () => void) : HttpResponse;
 
-    /** Handler for reading data from POST and such requests. You MUST copy the data of chunk if isLast is not true. We Neuter ArrayBuffers on return, making it zero length.*/
+    /** Handler for reading HTTP request body data.
+     * Must be attached before performing any asynchronous operation, otherwise data may be lost.
+     * You MUST copy the data of chunk if isLast is not true. We Neuter ArrayBuffers on return, making them zero length. */
     onData(handler: (chunk: ArrayBuffer, isLast: boolean) => void) : HttpResponse;
+    /** Pause HTTP request body streaming (throttle).
+     * Some buffered data may still be sent to onData. */
+    pause() : void;
+    /** Resume HTTP request body streaming (unthrottle). */
+    resume() : void;
 
     /** Returns the remote IP address in binary format (4 or 16 bytes). */
     getRemoteAddress() : ArrayBuffer;


### PR DESCRIPTION
Update onData() documentation:
- Change the term "reading data from POST and such requests" to "reading HTTP request body data".
- Add notice that onData must be attached before any asynchronous operation.
- Group the related pause() and resume() functions.
- Add pause() info that some buffered data may still be processed.