### PR TITLE
Update JsonPost example

### DIFF
--- a/examples/JsonPost.js
+++ b/examples/JsonPost.js
@@ -39,31 +39,18 @@ function readJson(res, cb, err) {
     let chunk = Buffer.from(ab);
     if (isLast) {
       let json;
-      if (buffer) {
-        try {
-          json = JSON.parse(Buffer.concat([buffer, chunk]));
-        } catch (e) {
-          /* res.close calls onAborted */
-          res.close();
-          return;
-        }
-        cb(json);
-      } else {
-        try {
-          json = JSON.parse(chunk);
-        } catch (e) {
-          /* res.close calls onAborted */
-          res.close();
-          return;
-        }
-        cb(json);
+      try {
+        json = JSON.parse(buffer ? Buffer.concat([buffer, chunk]) : chunk);
+      } catch (e) {
+        /* res.close calls onAborted */
+        res.close();
+        return;
       }
+      cb(json);
+    } else if (buffer) {
+      buffer = Buffer.concat([buffer, chunk]);
     } else {
-      if (buffer) {
-        buffer = Buffer.concat([buffer, chunk]);
-      } else {
-        buffer = Buffer.concat([chunk]);
-      }
+      buffer = Buffer.concat([chunk]);
     }
   });
 


### PR DESCRIPTION
Simplifying the readJson() helper function: remove the duplicated try-catch block.
Use "else if" instead of "else" followed by another "if".