### PR TITLE
adoptSocket: add optional ip parameter

### DIFF
--- a/src/AppWrapper.h
+++ b/src/AppWrapper.h
@@ -758,7 +758,12 @@ void uWS_App_adoptSocket(const FunctionCallbackInfo<Value> &args) {
 
     int32_t fd = args[0]->Int32Value(isolate->GetCurrentContext()).ToChecked();
 
-    app->adoptSocket(fd);
+    NativeString ip(isolate, args[1]);
+    if (ip.isInvalid(args)) {
+        return;
+    }
+
+    app->adoptSocket(fd, ip.getString());
 
     args.GetReturnValue().Set(args.This());
 }


### PR DESCRIPTION
Related to issue #1257.
Depends on uWS PR [1921](https://github.com/uNetworking/uWebSockets/pull/1921).

Update `adoptSocket()` to accept an optional IP parameter.
Allowing the IP to be correctly set in the uSockets open handler for the adopted socket.

If someone accepts external FD, needs the IP on the request and uses the UWS_REMOTE_ADDRESS_USERSPACE cache, they have to pass the IP to adoptSocket().