### PR TITLE
I reduced boilerplate

### DIFF
--- a/src/AppWrapper.h
+++ b/src/AppWrapper.h
@@ -15,14 +15,11 @@
  * limitations under the License.
  */
 
-#include "App.h"
-#include <v8.h>
 #include "Utilities.h"
-using namespace v8;
 
 /* uWS.App.ws('/pattern', behavior) */
 template <typename APP>
-void uWS_App_ws(const FunctionCallbackInfo<Value> &args) {
+void uWS_App_ws(args_t args) {
 
     /* pattern, behavior */
     if (missingArguments(2, args)) {
@@ -31,7 +28,7 @@ void uWS_App_ws(const FunctionCallbackInfo<Value> &args) {
 
     Isolate *isolate = args.GetIsolate();
 
-    PerContextData *perContextData = (PerContextData *) Local<External>::Cast(args.Data())->Value();
+    PerIsolateData *perIsolateData = (PerIsolateData *) Local<External>::Cast(args.Data())->Value();
 
     APP *app = (APP *) args.This()->GetAlignedPointerFromInternalField(0);
     /* This one is default constructed with defaults */
@@ -122,15 +119,15 @@ void uWS_App_ws(const FunctionCallbackInfo<Value> &args) {
 
     /* Upgrade handler is always optional */
     if (upgradePf != Undefined(isolate)) {
-        behavior.upgrade = [upgradePf = std::move(upgradePf), perContextData](auto *res, auto *req, auto *context) {
-            Isolate *isolate = perContextData->isolate;
+        behavior.upgrade = [upgradePf = std::move(upgradePf), perIsolateData](auto *res, auto *req, auto *context) {
+            Isolate *isolate = perIsolateData->isolate;
             HandleScope hs(isolate);
 
             Local<Function> upgradeLf = Local<Function>::New(isolate, upgradePf);
-            Local<Object> resObject = perContextData->resTemplate[getAppTypeIndex<APP>()].Get(isolate)->Clone();
+            Local<Object> resObject = perIsolateData->resTemplate[getAppTypeIndex<APP>()].Get(isolate)->Clone();
             resObject->SetAlignedPointerInInternalField(0, res);
 
-            Local<Object> reqObject = perContextData->reqTemplate[std::is_same<APP, uWS::H3App>::value].Get(isolate)->Clone();
+            Local<Object> reqObject = perIsolateData->reqTemplate[std::is_same<APP, uWS::H3App>::value].Get(isolate)->Clone();
             reqObject->SetAlignedPointerInInternalField(0, req);
 
             Local<Value> argv[3] = {resObject, reqObject, External::New(isolate, (void *) context)};
@@ -145,12 +142,12 @@ void uWS_App_ws(const FunctionCallbackInfo<Value> &args) {
     }
 
     /* Open handler is NOT optional for the wrapper */
-    behavior.open = [openPf = std::move(openPf), perContextData](auto *ws) {
-        Isolate *isolate = perContextData->isolate;
+    behavior.open = [openPf = std::move(openPf), perIsolateData](auto *ws) {
+        Isolate *isolate = perIsolateData->isolate;
         HandleScope hs(isolate);
 
         /* Create a new websocket object */
-        Local<Object> wsObject = perContextData->wsTemplate[getAppTypeIndex<APP>()].Get(isolate)->Clone();
+        Local<Object> wsObject = perIsolateData->wsTemplate[getAppTypeIndex<APP>()].Get(isolate)->Clone();
         wsObject->SetAlignedPointerInInternalField(0, ws);
 
         /* Retrieve temporary userData object */
@@ -310,7 +307,7 @@ void uWS_App_ws(const FunctionCallbackInfo<Value> &args) {
 
 /* This method wraps get, post and all http methods */
 template <typename APP, typename F>
-void uWS_App_get(F f, const FunctionCallbackInfo<Value> &args) {
+void uWS_App_get(F f, args_t args) {
     APP *app = (APP *) args.This()->GetAlignedPointerFromInternalField(0);
 
     /* Pattern */
@@ -456,17 +453,17 @@ void uWS_App_get(F f, const FunctionCallbackInfo<Value> &args) {
     }
     UniquePersistent<Function> cb = checkedCallback.getFunction();
 
-    /* This function requires perContextData */
-    PerContextData *perContextData = (PerContextData *) Local<External>::Cast(args.Data())->Value();
+    /* This function requires perIsolateData */
+    PerIsolateData *perIsolateData = (PerIsolateData *) Local<External>::Cast(args.Data())->Value();
 
-    (app->*f)(std::string(pattern.getString()), [cb = std::move(cb), perContextData](auto *res, auto *req) {
-        Isolate *isolate = perContextData->isolate;
+    (app->*f)(std::string(pattern.getString()), [cb = std::move(cb), perIsolateData](auto *res, auto *req) {
+        Isolate *isolate = perIsolateData->isolate;
         HandleScope hs(isolate);
 
-        Local<Object> resObject = perContextData->resTemplate[getAppTypeIndex<APP>()].Get(isolate)->Clone();
+        Local<Object> resObject = perIsolateData->resTemplate[getAppTypeIndex<APP>()].Get(isolate)->Clone();
         resObject->SetAlignedPointerInInternalField(0, res);
 
-        Local<Object> reqObject = perContextData->reqTemplate[std::is_same<APP, uWS::H3App>::value].Get(isolate)->Clone();
+        Local<Object> reqObject = perIsolateData->reqTemplate[std::is_same<APP, uWS::H3App>::value].Get(isolate)->Clone();
         reqObject->SetAlignedPointerInInternalField(0, req);
 
         Local<Value> argv[] = {resObject, reqObject};
@@ -483,7 +480,7 @@ void uWS_App_get(F f, const FunctionCallbackInfo<Value> &args) {
 }
 
 template <typename APP>
-void uWS_App_close(const FunctionCallbackInfo<Value> &args) {
+void uWS_App_close(args_t args) {
     APP *app = (APP *) args.This()->GetAlignedPointerFromInternalField(0);
 
     app->close();
@@ -491,7 +488,7 @@ void uWS_App_close(const FunctionCallbackInfo<Value> &args) {
 }
 
 template <typename APP>
-void uWS_App_listen_unix(const FunctionCallbackInfo<Value> &args) {
+void uWS_App_listen_unix(args_t args) {
     APP *app = (APP *) args.This()->GetAlignedPointerFromInternalField(0);
 
     Isolate *isolate = args.GetIsolate();
@@ -525,7 +522,7 @@ void uWS_App_listen_unix(const FunctionCallbackInfo<Value> &args) {
 }
 
 template <typename APP>
-void uWS_App_listen(const FunctionCallbackInfo<Value> &args) {
+void uWS_App_listen(args_t args) {
     APP *app = (APP *) args.This()->GetAlignedPointerFromInternalField(0);
 
     Isolate *isolate = args.GetIsolate();
@@ -567,7 +564,7 @@ void uWS_App_listen(const FunctionCallbackInfo<Value> &args) {
 }
 
 template <typename APP>
-void uWS_App_filter(const FunctionCallbackInfo<Value> &args) {
+void uWS_App_filter(args_t args) {
     APP *app = (APP *) args.This()->GetAlignedPointerFromInternalField(0);
 
     /* Handler */
@@ -577,14 +574,14 @@ void uWS_App_filter(const FunctionCallbackInfo<Value> &args) {
     }
     UniquePersistent<Function> cb = checkedCallback.getFunction();
 
-    /* This function requires perContextData */
-    PerContextData *perContextData = (PerContextData *) Local<External>::Cast(args.Data())->Value();
+    /* This function requires perIsolateData */
+    PerIsolateData *perIsolateData = (PerIsolateData *) Local<External>::Cast(args.Data())->Value();
 
-    app->filter([cb = std::move(cb), perContextData](auto *res, int count) {
-        Isolate *isolate = perContextData->isolate;
+    app->filter([cb = std::move(cb), perIsolateData](auto *res, int count) {
+        Isolate *isolate = perIsolateData->isolate;
         HandleScope hs(isolate);
 
-        Local<Object> resObject = perContextData->resTemplate[getAppTypeIndex<APP>()].Get(isolate)->Clone();
+        Local<Object> resObject = perIsolateData->resTemplate[getAppTypeIndex<APP>()].Get(isolate)->Clone();
         resObject->SetAlignedPointerInInternalField(0, res);
 
         Local<Value> argv[] = {resObject, Local<Value>::Cast(Integer::New(isolate, count))};
@@ -595,7 +592,7 @@ void uWS_App_filter(const FunctionCallbackInfo<Value> &args) {
 }
 
 template <typename APP>
-void uWS_App_domain(const FunctionCallbackInfo<Value> &args) {
+void uWS_App_domain(args_t args) {
     APP *app = (APP *) args.This()->GetAlignedPointerFromInternalField(0);
 
     Isolate *isolate = args.GetIsolate();
@@ -616,7 +613,7 @@ void uWS_App_domain(const FunctionCallbackInfo<Value> &args) {
 }
 
 template <typename APP>
-void uWS_App_publish(const FunctionCallbackInfo<Value> &args) {
+void uWS_App_publish(args_t args) {
     APP *app = (APP *) args.This()->GetAlignedPointerFromInternalField(0);
 
     Isolate *isolate = args.GetIsolate();
@@ -642,7 +639,7 @@ void uWS_App_publish(const FunctionCallbackInfo<Value> &args) {
 }
 
 template <typename APP>
-void uWS_App_numSubscribers(const FunctionCallbackInfo<Value> &args) {
+void uWS_App_numSubscribers(args_t args) {
     APP *app = (APP *) args.This()->GetAlignedPointerFromInternalField(0);
 
     Isolate *isolate = args.GetIsolate();
@@ -661,7 +658,7 @@ void uWS_App_numSubscribers(const FunctionCallbackInfo<Value> &args) {
 }
 
 /* This one modified per-thread static strings temporarily */
-std::pair<uWS::SocketContextOptions, bool> readOptionsObject(const FunctionCallbackInfo<Value> &args, int index) {
+std::pair<uWS::SocketContextOptions, bool> readOptionsObject(args_t args, int index) {
     Isolate *isolate = args.GetIsolate();
     /* Read the options object if any */
     uWS::SocketContextOptions options = {};
@@ -743,7 +740,7 @@ std::pair<uWS::SocketContextOptions, bool> readOptionsObject(const FunctionCallb
 }
 
 template <typename APP>
-void uWS_App_adoptSocket(const FunctionCallbackInfo<Value> &args) {
+void uWS_App_adoptSocket(args_t args) {
     APP *app = (APP *) args.This()->GetAlignedPointerFromInternalField(0);
 
     Isolate *isolate = args.GetIsolate();
@@ -756,7 +753,7 @@ void uWS_App_adoptSocket(const FunctionCallbackInfo<Value> &args) {
 }
 
 template <typename APP>
-void uWS_App_removeChildApp(const FunctionCallbackInfo<Value> &args) {
+void uWS_App_removeChildApp(args_t args) {
     APP *app = (APP *) args.This()->GetAlignedPointerFromInternalField(0);
 
     Isolate *isolate = args.GetIsolate();
@@ -772,7 +769,7 @@ void uWS_App_removeChildApp(const FunctionCallbackInfo<Value> &args) {
 }
 
 template <typename APP>
-void uWS_App_addChildApp(const FunctionCallbackInfo<Value> &args) {
+void uWS_App_addChildApp(args_t args) {
     APP *app = (APP *) args.This()->GetAlignedPointerFromInternalField(0);
 
     Isolate *isolate = args.GetIsolate();
@@ -795,7 +792,7 @@ void uWS_App_addChildApp(const FunctionCallbackInfo<Value> &args) {
 }
 
 template <typename APP>
-void uWS_App_getDescriptor(const FunctionCallbackInfo<Value> &args) {
+void uWS_App_getDescriptor(args_t args) {
     APP *app = (APP *) args.This()->GetAlignedPointerFromInternalField(0);
 
     Isolate *isolate = args.GetIsolate();
@@ -820,7 +817,7 @@ void uWS_App_getDescriptor(const FunctionCallbackInfo<Value> &args) {
 }
 
 template <typename APP>
-void uWS_App_addServerName(const FunctionCallbackInfo<Value> &args) {
+void uWS_App_addServerName(args_t args) {
     APP *app = (APP *) args.This()->GetAlignedPointerFromInternalField(0);
 
     Isolate *isolate = args.GetIsolate();
@@ -844,7 +841,7 @@ void uWS_App_addServerName(const FunctionCallbackInfo<Value> &args) {
 }
 
 template <typename APP>
-void uWS_App_removeServerName(const FunctionCallbackInfo<Value> &args) {
+void uWS_App_removeServerName(args_t args) {
     APP *app = (APP *) args.This()->GetAlignedPointerFromInternalField(0);
 
     Isolate *isolate = args.GetIsolate();
@@ -863,7 +860,7 @@ void uWS_App_removeServerName(const FunctionCallbackInfo<Value> &args) {
 }
 
 template <typename APP>
-void uWS_App_missingServerName(const FunctionCallbackInfo<Value> &args) {
+void uWS_App_missingServerName(args_t args) {
     APP *app = (APP *) args.This()->GetAlignedPointerFromInternalField(0);
     Isolate *isolate = args.GetIsolate();
 
@@ -882,9 +879,10 @@ void uWS_App_missingServerName(const FunctionCallbackInfo<Value> &args) {
 }
 
 template <typename APP>
-void uWS_App(const FunctionCallbackInfo<Value> &args) {
+void uWS_App(args_t args) {
 
     Isolate *isolate = args.GetIsolate();
+
     Local<FunctionTemplate> appTemplate = FunctionTemplate::New(isolate);
     appTemplate->SetClassName(String::NewFromUtf8(isolate, std::is_same<APP, uWS::SSLApp>::value ? "uWS.SSLApp" : "uWS.App", NewStringType::kNormal).ToLocalChecked());
 
@@ -915,10 +913,23 @@ void uWS_App(const FunctionCallbackInfo<Value> &args) {
     }
 
     appTemplate->InstanceTemplate()->SetInternalFieldCount(1);
+    
+    Local<ObjectTemplate> appObjectTemplate = appTemplate->PrototypeTemplate();
+    Local<Value> settings = args.Data();
 
+    /* helper */
+    auto regFn = [appObjectTemplate, isolate, settings]<size_t N>(
+      const char (&str)[N],
+      void(*cb)(args_t)
+    ){
+      appObjectTemplate->Set(
+        String::NewFromUtf8(isolate, str, NewStringType::kNormal, N-1).ToLocalChecked(),
+        FunctionTemplate::New(isolate, cb, settings)
+      );
+    };
 
     /* All the http methods */
-    appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "get", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, [](auto &args) {
+    regFn("get", [](auto &args) {
         
         /* Add non-cached variants */
         if constexpr (std::is_same<APP, uWS::App>::value) {
@@ -941,10 +952,10 @@ void uWS_App(const FunctionCallbackInfo<Value> &args) {
                 if (checkedCallback.isInvalid(args)) {
                     return;
                 }
-                UniquePersistent<Function> cb = checkedCallback.getFunction();
+                Global<Function> cb = checkedCallback.getFunction();
 
                 /* This function requires perContextData */
-                PerContextData *perContextData = (PerContextData *) Local<External>::Cast(args.Data())->Value();
+                PerIsolateData *perContextData = (PerIsolateData *) Local<External>::Cast(args.Data())->Value();
 
                 app->get(std::string(pattern.getString()), [cb = std::move(cb), perContextData](auto *res, auto *req) {
                     Isolate *isolate = perContextData->isolate;
@@ -979,77 +990,77 @@ void uWS_App(const FunctionCallbackInfo<Value> &args) {
             uWS_App_get<APP>(&uWS::TemplatedApp<true>::get, args);
         }
        
-    }, args.Data()));
+    });
 
-    appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "post", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, [](auto &args) {
+    regFn("post", [](args_t args) {
         uWS_App_get<APP>(&APP::post, args);
-    }, args.Data()));
+    });
 
-    appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "options", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, [](auto &args) {
+    regFn("options", [](args_t args) {
         uWS_App_get<APP>(&APP::options, args);
-    }, args.Data()));
+    });
 
-    appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "del", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, [](auto &args) {
+    regFn("del", [](args_t args) {
         uWS_App_get<APP>(&APP::del, args);
-    }, args.Data()));
+    });
 
-    appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "patch", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, [](auto &args) {
+    regFn("patch", [](args_t args) {
         uWS_App_get<APP>(&APP::patch, args);
-    }, args.Data()));
+    });
 
-    appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "put", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, [](auto &args) {
+    regFn("put", [](args_t args) {
         uWS_App_get<APP>(&APP::put, args);
-    }, args.Data()));
+    });
 
-    appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "head", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, [](auto &args) {
+    regFn("head", [](args_t args) {
         uWS_App_get<APP>(&APP::head, args);
-    }, args.Data()));
+    });
 
-    appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "connect", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, [](auto &args) {
+    regFn("connect", [](args_t args) {
         uWS_App_get<APP>(&APP::connect, args);
-    }, args.Data()));
+    });
 
-    appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "trace", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, [](auto &args) {
+    regFn("trace", [](args_t args) {
         uWS_App_get<APP>(&APP::trace, args);
-    }, args.Data()));
+    });
 
     /* Any http method */
-    appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "any", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, [](auto &args) {
+    regFn("any", [](args_t args) {
         uWS_App_get<APP>(&APP::any, args);
-    }, args.Data()));
+    });
 
-    appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "listen", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_App_listen<APP>, args.Data()));
+    regFn("listen", uWS_App_listen<APP>);
     
     if constexpr (!std::is_same<APP, uWS::H3App>::value) {
-
-        appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "close", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_App_close<APP>, args.Data()));
-        appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "listen_unix", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_App_listen_unix<APP>, args.Data()));
-        appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "filter", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_App_filter<APP>, args.Data()));
+        /* helper */
+        regFn("close", uWS_App_close<APP>);
+        regFn("listen_unix", uWS_App_listen_unix<APP>);
+        regFn("filter", uWS_App_filter<APP>);
 
         /* load balancing */
-        appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "removeChildAppDescriptor", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_App_removeChildApp<APP>, args.Data()));
-        appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "addChildAppDescriptor", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_App_addChildApp<APP>, args.Data()));
-        appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getDescriptor", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_App_getDescriptor<APP>, args.Data()));
-        appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "adoptSocket", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_App_adoptSocket<APP>, args.Data()));
+        regFn("removeChildAppDescriptor", uWS_App_removeChildApp<APP>);
+        regFn("addChildAppDescriptor", uWS_App_addChildApp<APP>);
+        regFn("getDescriptor", uWS_App_getDescriptor<APP>);
+        regFn("adoptSocket", uWS_App_adoptSocket<APP>);
 
         /* ws, listen */
-        appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "ws", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_App_ws<APP>, args.Data()));
-        appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "publish", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_App_publish<APP>, args.Data()));
-        appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "numSubscribers", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_App_numSubscribers<APP>, args.Data()));
+        regFn("ws", uWS_App_ws<APP>);
+        regFn("publish", uWS_App_publish<APP>);
+        regFn("numSubscribers", uWS_App_numSubscribers<APP>);
 
-        appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "domain", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_App_domain<APP>, args.Data()));
+        regFn("domain", uWS_App_domain<APP>);
 
         /* SNI */
-        appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "addServerName", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_App_addServerName<APP>, args.Data()));
-        appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "removeServerName", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_App_removeServerName<APP>, args.Data()));
-        appTemplate->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "missingServerName", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_App_missingServerName<APP>, args.Data()));
+        regFn("addServerName", uWS_App_addServerName<APP>);
+        regFn("removeServerName", uWS_App_removeServerName<APP>);
+        regFn("missingServerName", uWS_App_missingServerName<APP>);
 
     }
 
     Local<Object> localApp = appTemplate->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()->NewInstance(isolate->GetCurrentContext()).ToLocalChecked();
     localApp->SetAlignedPointerInInternalField(0, app);
 
-    PerContextData *perContextData = (PerContextData *) Local<External>::Cast(args.Data())->Value();
+    PerIsolateData *perContextData = (PerIsolateData *) Local<External>::Cast(args.Data())->Value();
 
 
     if constexpr (!std::is_same<APP, uWS::H3App>::value) {
@@ -1064,5 +1075,4 @@ void uWS_App(const FunctionCallbackInfo<Value> &args) {
     }
 
     args.GetReturnValue().Set(localApp);
-
 }

--- a/src/HttpRequestWrapper.h
+++ b/src/HttpRequestWrapper.h
@@ -15,18 +15,14 @@
  * limitations under the License.
  */
 
-#include "App.h"
 #include "Utilities.h"
 
-#include <v8.h>
-using namespace v8;
-
 /* This one is the same for SSL and non-SSL */
-struct HttpRequestWrapper {
+namespace HttpRequestWrapper {
 
     /* Unwraps the HttpRequest from V8 object */
     template <int QUIC>
-    static inline constexpr decltype(auto) getHttpRequest(const FunctionCallbackInfo<Value> &args) {
+    inline constexpr decltype(auto) getHttpRequest(args_t args) {
         Isolate *isolate = args.GetIsolate();
         /* Thow on deleted request */
         auto *req = (uWS::HttpRequest *) args.This()->GetAlignedPointerFromInternalField(0);
@@ -43,7 +39,7 @@ struct HttpRequestWrapper {
 
     /* Takes function of string, string. Returns this (doesn't really but should) */
     template <int QUIC>
-    static void req_forEach(const FunctionCallbackInfo<Value> &args) {
+    void req_forEach(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *req = getHttpRequest<QUIC>(args);
         if (req) {
@@ -60,7 +56,7 @@ struct HttpRequestWrapper {
 
     /* Takes int or string, returns string (must be in bounds) */
     template <int QUIC>
-    static void req_getParameter(const FunctionCallbackInfo<Value> &args) {
+    void req_getParameter(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *req = getHttpRequest<QUIC>(args);
         if (req) {
@@ -84,7 +80,7 @@ struct HttpRequestWrapper {
 
     /* Takes nothing, returns string */
     template <int QUIC>
-    static void req_getUrl(const FunctionCallbackInfo<Value> &args) {
+    void req_getUrl(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *req = getHttpRequest<QUIC>(args);
         if (req) {
@@ -96,7 +92,7 @@ struct HttpRequestWrapper {
 
     /* Takes String, returns String */
     template <int QUIC>
-    static void req_getHeader(const FunctionCallbackInfo<Value> &args) {
+    void req_getHeader(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *req = getHttpRequest<QUIC>(args);
         if (req) {
@@ -114,7 +110,7 @@ struct HttpRequestWrapper {
 
     /* Takes boolean, returns this */
     template <int QUIC>
-    static void req_setYield(const FunctionCallbackInfo<Value> &args) {
+    void req_setYield(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *req = getHttpRequest<QUIC>(args);
         if (req) {
@@ -127,7 +123,7 @@ struct HttpRequestWrapper {
 
     /* Takes nothing, returns string */
     template <int QUIC>
-    static void req_getMethod(const FunctionCallbackInfo<Value> &args) {
+    void req_getMethod(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *req = getHttpRequest<QUIC>(args);
         if (req) {
@@ -139,7 +135,7 @@ struct HttpRequestWrapper {
 
     /* Takes nothing, returns string */
     template <int QUIC>
-    static void req_getCaseSensitiveMethod(const FunctionCallbackInfo<Value> &args) {
+    void req_getCaseSensitiveMethod(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *req = getHttpRequest<QUIC>(args);
         if (req) {
@@ -150,7 +146,7 @@ struct HttpRequestWrapper {
     }
 
     template <int QUIC>
-    static void req_getQuery(const FunctionCallbackInfo<Value> &args) {
+    void req_getQuery(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *req = getHttpRequest<QUIC>(args);
         if (req) {
@@ -177,30 +173,42 @@ struct HttpRequestWrapper {
         }
     }
 
-    /* Returns a clonable object wrapping an HttpRequest */
+ /* Returns a clonable object wrapping an HttpRequest */
     template <int QUIC>
-    static Local<Object> init(Isolate *isolate) {
+    Local<Object> init(Isolate *isolate) {
         /* We do clone every request object, we could share them, they are illegal to use outside the function anyways */
         Local<FunctionTemplate> reqTemplateLocal = FunctionTemplate::New(isolate);
-        reqTemplateLocal->SetClassName(String::NewFromUtf8(isolate, QUIC ? "uWS.Http3Request" : "uWS.HttpRequest", NewStringType::kNormal).ToLocalChecked());
+        reqTemplateLocal->SetClassName(String::NewFromUtf8(isolate, QUIC == 2 ? "uWS.Http3Request" : "uWS.HttpRequest", NewStringType::kNormal).ToLocalChecked());
         reqTemplateLocal->InstanceTemplate()->SetInternalFieldCount(1);
 
+        /* helper */
+          auto regFn = [reqTemplateObject = reqTemplateLocal->PrototypeTemplate(), isolate]<size_t N>(
+            const char (&str)[N],
+            void(*cb)(args_t)
+          ){
+            reqTemplateObject->Set(
+              String::NewFromUtf8(isolate, str, NewStringType::kNormal, N-1).ToLocalChecked(),
+              FunctionTemplate::New(isolate, cb)
+            );
+          };
+
         /* Register our functions */
-        reqTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getHeader", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, req_getHeader<QUIC>));
+        regFn("getHeader", req_getHeader<QUIC>);
         
-        if constexpr (!QUIC) {
-            reqTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getParameter", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, req_getParameter<QUIC>));
-            reqTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getUrl", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, req_getUrl<QUIC>));
-            reqTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getMethod", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, req_getMethod<QUIC>));
-            reqTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getCaseSensitiveMethod", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, req_getCaseSensitiveMethod<QUIC>));
-            reqTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getQuery", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, req_getQuery<QUIC>));
-            reqTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "forEach", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, req_forEach<QUIC>));
-            reqTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "setYield", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, req_setYield<QUIC>));
+        if constexpr (QUIC == 0) {
+          regFn("getParameter", req_getParameter<QUIC>);
+          regFn("getUrl", req_getUrl<QUIC>);
+          regFn("getMethod", req_getMethod<QUIC>);
+          regFn("getCaseSensitiveMethod", req_getCaseSensitiveMethod<QUIC>);
+          regFn("getQuery", req_getQuery<QUIC>);
+          regFn("forEach", req_forEach<QUIC>);
+          regFn("setYield", req_setYield<QUIC>);
         }
 
 
         /* Create the template */
-        Local<Object> reqObjectLocal = reqTemplateLocal->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()->NewInstance(isolate->GetCurrentContext()).ToLocalChecked();
+        Local<Context> context = isolate->GetCurrentContext();
+        Local<Object> reqObjectLocal = reqTemplateLocal->GetFunction(context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
 
         return reqObjectLocal;
     }

--- a/src/HttpResponseWrapper.h
+++ b/src/HttpResponseWrapper.h
@@ -15,26 +15,22 @@
  * limitations under the License.
  */
 
-#include "App.h"
 #include "Utilities.h"
-
-#include <v8.h>
-using namespace v8;
 
 thread_local int insideCorkCallback = 0;
 
 /* PROTOCOL is 0 = TCP, 1 = TLS, 2 = QUIC, 3 = CACHE */
 
-struct HttpResponseWrapper {
+namespace HttpResponseWrapper {
 
-    static void assumeCorked() {
+    void assumeCorked() {
         if (!insideCorkCallback) {
             std::cerr << "Warning: uWS.HttpResponse writes must be made from within a corked callback. See documentation for uWS.HttpResponse.cork and consult the user manual." << std::endl;
         }
     }
 
     template <int PROTOCOL>
-    static inline constexpr decltype(auto) getHttpResponse(const FunctionCallbackInfo<Value> &args) {
+    inline constexpr decltype(auto) getHttpResponse(args_t args) {
         Isolate *isolate = args.GetIsolate();
         void *res = args.This()->GetAlignedPointerFromInternalField(0);
         if (!res) {
@@ -52,13 +48,13 @@ struct HttpResponseWrapper {
     }
 
     /* Marks this JS object invalid */
-    static inline void invalidateResObject(const FunctionCallbackInfo<Value> &args) {
+    inline void invalidateResObject(args_t args) {
         args.This()->SetAlignedPointerInInternalField(0, nullptr);
     }
 
     /* Takes nothing, returns this */
     template <int SSL>
-    static void res_pause(const FunctionCallbackInfo<Value> &args) {
+    void res_pause(args_t args) {
         auto *res = getHttpResponse<SSL>(args);
         if (res) {
             res->pause();
@@ -68,7 +64,7 @@ struct HttpResponseWrapper {
 
     /* Takes nothing, returns this */
     template <int SSL>
-    static void res_resume(const FunctionCallbackInfo<Value> &args) {
+    void res_resume(args_t args) {
         auto *res = getHttpResponse<SSL>(args);
         if (res) {
             res->resume();
@@ -78,7 +74,7 @@ struct HttpResponseWrapper {
 
     /* Takes nothing, kills the connection */
     template <int SSL>
-    static void res_close(const FunctionCallbackInfo<Value> &args) {
+    void res_close(args_t args) {
         auto *res = getHttpResponse<SSL>(args);
         if (res) {
             invalidateResObject(args);
@@ -89,7 +85,7 @@ struct HttpResponseWrapper {
 
     /* Takes function of data and isLast. Expects nothing from callback, returns this */
     template <int SSL>
-    static void res_onData(const FunctionCallbackInfo<Value> &args) {
+    void res_onData(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *res = getHttpResponse<SSL>(args);
         if (res) {
@@ -118,7 +114,7 @@ struct HttpResponseWrapper {
      * accumulated into a std::vector whose memory is transferred zero-copy into the ArrayBuffer backing store.
      * Returns this */
     template <int SSL>
-    static void res_collectBody(const FunctionCallbackInfo<Value> &args) {
+    void res_collectBody(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *res = getHttpResponse<SSL>(args);
         if (res) {
@@ -192,7 +188,7 @@ struct HttpResponseWrapper {
     /* Takes function of chunk and maxRemainingBodyLength. Returns this.
      * If maxRemainingBodyLength is 0, the last chunk has arrived. */
     template <int SSL>
-    static void res_onDataV2(const FunctionCallbackInfo<Value> &args) {
+    void res_onDataV2(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *res = getHttpResponse<SSL>(args);
         if (res) {
@@ -217,7 +213,7 @@ struct HttpResponseWrapper {
 
     /* Takes nothing, returns nothing. Cb wants nothing returned. */
     template <int SSL>
-    static void res_onAborted(const FunctionCallbackInfo<Value> &args) {
+    void res_onAborted(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *res = getHttpResponse<SSL>(args);
         if (res) {
@@ -242,7 +238,7 @@ struct HttpResponseWrapper {
 
     /* Takes nothing, returns arraybuffer */
     template <int SSL>
-    static void res_getRemoteAddress(const FunctionCallbackInfo<Value> &args) {
+    void res_getRemoteAddress(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *res = getHttpResponse<SSL>(args);
         if (res) {
@@ -254,7 +250,7 @@ struct HttpResponseWrapper {
 
     /* Takes nothing, returns arraybuffer */
     template <int SSL>
-    static void res_getRemoteAddressAsText(const FunctionCallbackInfo<Value> &args) {
+    void res_getRemoteAddressAsText(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *res = getHttpResponse<SSL>(args);
         if (res) {
@@ -266,7 +262,7 @@ struct HttpResponseWrapper {
 
     /* Takes nothing, returns integer */
     template <int SSL>
-    static void res_getRemotePort(const FunctionCallbackInfo<Value> &args) {
+    void res_getRemotePort(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *res = getHttpResponse<SSL>(args);
         if (res) {
@@ -278,7 +274,7 @@ struct HttpResponseWrapper {
 
     /* Takes nothing, returns arraybuffer */
     template <int SSL>
-    static void res_getProxiedRemoteAddress(const FunctionCallbackInfo<Value> &args) {
+    void res_getProxiedRemoteAddress(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *res = getHttpResponse<SSL>(args);
         if (res) {
@@ -290,7 +286,7 @@ struct HttpResponseWrapper {
 
     /* Takes nothing, returns arraybuffer */
     template <int SSL>
-    static void res_getProxiedRemoteAddressAsText(const FunctionCallbackInfo<Value> &args) {
+    void res_getProxiedRemoteAddressAsText(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *res = getHttpResponse<SSL>(args);
         if (res) {
@@ -302,7 +298,7 @@ struct HttpResponseWrapper {
 
     /* Takes nothing, returns number */
     template <int SSL>
-    static void res_getProxiedRemotePort(const FunctionCallbackInfo<Value> &args) {
+    void res_getProxiedRemotePort(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *res = getHttpResponse<SSL>(args);
         if (res) {
@@ -313,7 +309,7 @@ struct HttpResponseWrapper {
     }
 
     template <int PROTOCOL>
-    static void res_getX509Certificate(const FunctionCallbackInfo<Value> &args) {
+    void res_getX509Certificate(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *res = getHttpResponse<PROTOCOL>(args);
         if (res) {
@@ -326,7 +322,7 @@ struct HttpResponseWrapper {
 
     /* Returns the current write offset */
     template <int SSL>
-    static void res_getWriteOffset(const FunctionCallbackInfo<Value> &args) {
+    void res_getWriteOffset(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *res = getHttpResponse<SSL>(args);
         if (res) {
@@ -336,7 +332,7 @@ struct HttpResponseWrapper {
 
     /* Takes function of bool(int), returns this */
     template <int SSL>
-    static void res_onWritable(const FunctionCallbackInfo<Value> &args) {
+    void res_onWritable(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *res = getHttpResponse<SSL>(args);
         if (res) {
@@ -366,7 +362,7 @@ struct HttpResponseWrapper {
 
     /* Takes string or arraybuffer, returns this */
     template <int SSL>
-    static void res_writeStatus(const FunctionCallbackInfo<Value> &args) {
+    void res_writeStatus(args_t args) {
         auto *res = getHttpResponse<SSL>(args);
             if (res) {
             NativeString<true> data(args.GetIsolate(), args[0]);
@@ -383,7 +379,7 @@ struct HttpResponseWrapper {
 
     /* Takes number, bool */
     template <int SSL>
-    static void res_endWithoutBody(const FunctionCallbackInfo<Value> &args) {
+    void res_endWithoutBody(args_t args) {
         auto *res = getHttpResponse<SSL>(args);
         if (res) {
             std::optional<size_t> reportedContentLength;
@@ -406,7 +402,7 @@ struct HttpResponseWrapper {
 
     /* Takes string or arraybuffer, returns this */
     template <int PROTOCOL>
-    static void res_end(const FunctionCallbackInfo<Value> &args) {
+    void res_end(args_t args) {
         auto *res = getHttpResponse<PROTOCOL>(args);
         if (res) {
             NativeString<true> data(args.GetIsolate(), args[0]);
@@ -430,7 +426,7 @@ struct HttpResponseWrapper {
 
     /* Takes data and optionally totalLength, returns true for success, false for backpressure */
     template <int PROTOCOL>
-    static void res_tryEnd(const FunctionCallbackInfo<Value> &args) {
+    void res_tryEnd(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *res = getHttpResponse<PROTOCOL>(args);
         if (res) {
@@ -463,7 +459,7 @@ struct HttpResponseWrapper {
 
     /* Takes data, returns true for success, false for backpressure */
     template <int PROTOCOL>
-    static void res_write(const FunctionCallbackInfo<Value> &args) {
+    void res_write(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *res = getHttpResponse<PROTOCOL>(args);
         if (res) {
@@ -480,7 +476,7 @@ struct HttpResponseWrapper {
 
     /* Takes key, value. Returns this */
     template <int PROTOCOL>
-    static void res_writeHeader(const FunctionCallbackInfo<Value> &args) {
+    void res_writeHeader(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *res = getHttpResponse<PROTOCOL>(args);
         if (res) {
@@ -503,7 +499,7 @@ struct HttpResponseWrapper {
 
     /* Takes function, returns this */
     template <int SSL>
-    static void res_cork(const FunctionCallbackInfo<Value> &args) {
+    void res_cork(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *res = getHttpResponse<SSL>(args);
         if (res) {
@@ -521,7 +517,7 @@ struct HttpResponseWrapper {
 
     /* Takes UserData, secKey, secProtocol, secExtensions, context. Returns nothing */
     template <int SSL>
-    static void res_upgrade(const FunctionCallbackInfo<Value> &args) {
+    void res_upgrade(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *res = getHttpResponse<SSL>(args);
         if (res) {
@@ -565,61 +561,79 @@ struct HttpResponseWrapper {
     }
 
     /* 0 = TCP, 1 = TLS, 2 = QUIC, 3 = CACHE */
-    template <int SSL>
-    static Local<Object> init(Isolate *isolate) {
-        Local<FunctionTemplate> resTemplateLocal = FunctionTemplate::New(isolate);
-        if (SSL == 1) {
-            resTemplateLocal->SetClassName(String::NewFromUtf8(isolate, "uWS.SSLHttpResponse", NewStringType::kNormal).ToLocalChecked());
-        } else if (SSL == 0) {
-            resTemplateLocal->SetClassName(String::NewFromUtf8(isolate, "uWS.HttpResponse", NewStringType::kNormal).ToLocalChecked());
-        } else if (SSL == 2) {
-            resTemplateLocal->SetClassName(String::NewFromUtf8(isolate, "uWS.Http3Response", NewStringType::kNormal).ToLocalChecked());
-        } else if (SSL == 3) {
-            resTemplateLocal->SetClassName(String::NewFromUtf8(isolate, "uWS.CachedHttpResponse", NewStringType::kNormal).ToLocalChecked());
-        }
-        resTemplateLocal->InstanceTemplate()->SetInternalFieldCount(1);
+    template <int Option>
+    Local<Object> init(Isolate *isolate) {
+        Local<FunctionTemplate> resTemplate = FunctionTemplate::New(isolate);
+
+        constexpr const char* classnames[4] = {
+          "uWS.HttpResponse",
+          "uWS.SSLHttpResponse", 
+          "uWS.Http3Response",
+          "uWS.CachedHttpResponse"
+        };
+        resTemplate->SetClassName(
+            String::NewFromUtf8(isolate, classnames[static_cast<uint32_t>(Option)], NewStringType::kNormal).ToLocalChecked()
+        );
+
+        resTemplate->InstanceTemplate()->SetInternalFieldCount(1);
+
+        Local<ObjectTemplate> resObjectTemplate = resTemplate->PrototypeTemplate();
+        /* helper */
+        auto regFn = [resObjectTemplate, isolate]<size_t N>(
+          const char (&str)[N],
+          void(*cb)(args_t)
+        ){
+          resObjectTemplate->Set(
+            String::NewFromUtf8(isolate, str, NewStringType::kNormal, N-1).ToLocalChecked(),
+            FunctionTemplate::New(isolate, cb)
+          );
+        };
 
         /* Register our functions */
-        resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "end", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_end<SSL>));
+        regFn("end", res_end<Option>);
         
         /* Cache has almost nothing wrapped yet */
-        if constexpr (SSL != 3) {
-            resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "writeStatus", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_writeStatus<SSL>));
-            resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "endWithoutBody", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_endWithoutBody<SSL>));
-            resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "tryEnd", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_tryEnd<SSL>));
-            resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "write", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_write<SSL>));
-            resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "writeHeader", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_writeHeader<SSL>));
-            resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "close", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_close<SSL>));
-            resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "onWritable", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_onWritable<SSL>));
-            resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "onAborted", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_onAborted<SSL>));
-            resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "onData", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_onData<SSL>));
+        if constexpr (Option != 3) {
+            regFn("writeStatus", res_writeStatus<Option>);
+            regFn("endWithoutBody", res_endWithoutBody<Option>);
+            regFn("tryEnd", res_tryEnd<Option>);
+            regFn("write", res_write<Option>);
+            regFn("writeHeader", res_writeHeader<Option>);
+            regFn("close", res_close<Option>);
+            regFn("onWritable", res_onWritable<Option>);
+            regFn("onAborted", res_onAborted<Option>);
+            regFn("onData", res_onData<Option>);
             
             /* QUIC has a lot of functions unimplemented */
-            if constexpr (SSL != 2) {
-                resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "onDataV2", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_onDataV2<SSL>));
-                resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "collectBody", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_collectBody<SSL>));
-                resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getWriteOffset", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_getWriteOffset<SSL>));
-                resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getRemoteAddress", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_getRemoteAddress<SSL>));
-                resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "cork", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_cork<SSL>));
-                resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "collect", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_cork<SSL>));
-                resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "upgrade", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_upgrade<SSL>));
-                resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getRemoteAddressAsText", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_getRemoteAddressAsText<SSL>));
-                resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getRemotePort", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_getRemotePort<SSL>));
-                resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getProxiedRemoteAddress", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_getProxiedRemoteAddress<SSL>));
-                resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getProxiedRemoteAddressAsText", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_getProxiedRemoteAddressAsText<SSL>));
-                resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getProxiedRemotePort", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_getProxiedRemotePort<SSL>));
-                resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "pause", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_pause<SSL>));
-                resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "resume", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_resume<SSL>));
+            if constexpr (Option != 2) {
+                regFn("onDataV2", res_onDataV2<Option>);
+                regFn("collectBody", res_collectBody<Option>);
+                regFn("getWriteOffset", res_getWriteOffset<Option>);
+                regFn("getRemoteAddress", res_getRemoteAddress<Option>);
+                regFn("cork", res_cork<Option>);
+
+                // hmmmm...
+                regFn("collect", res_cork<Option>);
+
+                regFn("upgrade", res_upgrade<Option>);
+                regFn("getRemoteAddressAsText", res_getRemoteAddressAsText<Option>);
+                regFn("getRemotePort", res_getRemotePort<Option>);
+                regFn("getProxiedRemoteAddress", res_getProxiedRemoteAddress<Option>);
+                regFn("getProxiedRemoteAddressAsText", res_getProxiedRemoteAddressAsText<Option>);
+                regFn("getProxiedRemotePort", res_getProxiedRemotePort<Option>);
+                regFn("pause", res_pause<Option>);
+                regFn("resume", res_resume<Option>);
+            }
+            if constexpr (Option == 1) {
+              regFn("getX509Certificate", res_getX509Certificate<Option>);
             }
         }
+        Local<FunctionTemplate> resTemplateLocal = FunctionTemplate::New(isolate);
+                resTemplateLocal->InstanceTemplate()->SetInternalFieldCount(1);
 
-        if constexpr (SSL == 1) {
-            resTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getX509Certificate", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, res_getX509Certificate<SSL>));
-        }
         
         /* Create our template */
         Local<Object> resObjectLocal = resTemplateLocal->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()->NewInstance(isolate->GetCurrentContext()).ToLocalChecked();
 
         return resObjectLocal;
-    }
-};
+    }};

--- a/src/Utilities.h
+++ b/src/Utilities.h
@@ -17,11 +17,16 @@
 
 #ifndef ADDON_UTILITIES_H
 #define ADDON_UTILITIES_H
+// this header file contains utilities and is used almost everywhere, so let it be central header-file
+#include "App.h"
+#include "Http3App.h"
 
+// helper to make life easier
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
 #include <v8.h>
 using namespace v8;
+using args_t = const FunctionCallbackInfo<Value>&;
 
 /* Unfortunately we _have_ to depend on Node.js crap */
 #include <node.h>
@@ -52,7 +57,7 @@ struct PerSocketData {
     UniquePersistent<Object> socketPf;
 };
 
-struct PerContextData {
+struct PerIsolateData {
     Isolate *isolate;
     UniquePersistent<Object> reqTemplate[2]; // 0 = non-SSL/SSL, 1 = Http3
     UniquePersistent<Object> resTemplate[4]; // 0 = non-SSL, 1 = SSL, 2 = Http3

--- a/src/WebSocketWrapper.h
+++ b/src/WebSocketWrapper.h
@@ -15,19 +15,16 @@
  * limitations under the License.
  */
 
-#include "App.h"
 #include "Utilities.h"
 
-#include <v8.h>
 #include "v8-fast-api-calls.h"
-using namespace v8;
 
 /* todo: probably isCorked, cork should be exposed? */
 
-struct WebSocketWrapper {
+namespace WebSocketWrapper {
 
     template <bool SSL>
-    static inline uWS::WebSocket<SSL, true, PerSocketData> *getWebSocket(const FunctionCallbackInfo<Value> &args) {
+    inline uWS::WebSocket<SSL, true, PerSocketData> *getWebSocket(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *ws = (uWS::WebSocket<SSL, true, PerSocketData> *) args.This()->GetAlignedPointerFromInternalField(0);
         if (!ws) {
@@ -36,19 +33,18 @@ struct WebSocketWrapper {
         return ws;
     }
 
-    static inline void invalidateWsObject(const FunctionCallbackInfo<Value> &args) {
+    inline void invalidateWsObject(args_t args) {
         args.This()->SetAlignedPointerInInternalField(0, nullptr);
     }
 
     /* Takes nothing returns holder (only used to fool TypeScript, as a conversion from WS to UserData) */
-    template <bool SSL>
-    static void uWS_WebSocket_getUserData(const FunctionCallbackInfo<Value> &args) {
+    void uWS_WebSocket_getUserData(args_t args) {
         args.GetReturnValue().Set(args.This());
     }
 
     /* Takes string topic */
     template <bool SSL>
-    static void uWS_WebSocket_subscribe(const FunctionCallbackInfo<Value> &args) {
+    void uWS_WebSocket_subscribe(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *ws = getWebSocket<SSL>(args);
         if (ws) {
@@ -63,7 +59,7 @@ struct WebSocketWrapper {
 
     /* Takes string topic, returns boolean success */
     template <bool SSL>
-    static void uWS_WebSocket_unsubscribe(const FunctionCallbackInfo<Value> &args) {
+    void uWS_WebSocket_unsubscribe(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *ws = getWebSocket<SSL>(args);
         if (ws) {
@@ -78,7 +74,7 @@ struct WebSocketWrapper {
 
     /* Takes string topic, message, returns boolean success */
     template <bool SSL>
-    static void uWS_WebSocket_publish(const FunctionCallbackInfo<Value> &args) {
+    void uWS_WebSocket_publish(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *ws = getWebSocket<SSL>(args);
         if (ws) {
@@ -108,7 +104,7 @@ struct WebSocketWrapper {
 
     /* Takes nothing returns nothing */
     template <bool SSL>
-    static void uWS_WebSocket_close(const FunctionCallbackInfo<Value> &args) {
+    void uWS_WebSocket_close(args_t args) {
         auto *ws = getWebSocket<SSL>(args);
         if (ws) {
             invalidateWsObject(args);
@@ -118,7 +114,7 @@ struct WebSocketWrapper {
 
     /* Takes code, message, returns undefined */
     template <bool SSL>
-    static void uWS_WebSocket_end(const FunctionCallbackInfo<Value> &args) {
+    void uWS_WebSocket_end(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *ws = getWebSocket<SSL>(args);
         if (ws) {
@@ -139,7 +135,7 @@ struct WebSocketWrapper {
 
     /* Takes nothing returns arraybuffer */
     template <bool SSL>
-    static void uWS_WebSocket_getRemoteAddress(const FunctionCallbackInfo<Value> &args) {
+    void uWS_WebSocket_getRemoteAddress(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *ws = getWebSocket<SSL>(args);
         if (ws) {
@@ -151,7 +147,7 @@ struct WebSocketWrapper {
 
     /* Takes nothing returns arraybuffer */
     template <bool SSL>
-    static void uWS_WebSocket_getRemoteAddressAsText(const FunctionCallbackInfo<Value> &args) {
+    void uWS_WebSocket_getRemoteAddressAsText(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *ws = getWebSocket<SSL>(args);
         if (ws) {
@@ -163,7 +159,7 @@ struct WebSocketWrapper {
 
     /* Takes nothing, returns integer */
     template <bool SSL>
-    static void uWS_WebSocket_getRemotePort(const FunctionCallbackInfo<Value> &args) {
+    void uWS_WebSocket_getRemotePort(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *ws = getWebSocket<SSL>(args);
         if (ws) {
@@ -174,7 +170,7 @@ struct WebSocketWrapper {
 
     /* Takes nothing, returns integer */
     template <bool SSL>
-    static void uWS_WebSocket_getBufferedAmount(const FunctionCallbackInfo<Value> &args) {
+    void uWS_WebSocket_getBufferedAmount(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *ws = getWebSocket<SSL>(args);
         if (ws) {
@@ -185,7 +181,7 @@ struct WebSocketWrapper {
 
     /* Takes message, isBinary, compressed. Returns true on success, false otherwise */
     template <bool SSL>
-    static void uWS_WebSocket_sendFirstFragment(const FunctionCallbackInfo<Value> &args) {
+    void uWS_WebSocket_sendFirstFragment(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *ws = getWebSocket<SSL>(args);
         if (ws) {
@@ -202,7 +198,7 @@ struct WebSocketWrapper {
 
     /* Takes message, compressed. Returns true on success, false otherwise */
     template <bool SSL>
-    static void uWS_WebSocket_sendFragment(const FunctionCallbackInfo<Value> &args) {
+    void uWS_WebSocket_sendFragment(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *ws = getWebSocket<SSL>(args);
         if (ws) {
@@ -219,7 +215,7 @@ struct WebSocketWrapper {
 
     /* Takes message, compressed. Returns true on success, false otherwise */
     template <bool SSL>
-    static void uWS_WebSocket_sendLastFragment(const FunctionCallbackInfo<Value> &args) {
+    void uWS_WebSocket_sendLastFragment(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *ws = getWebSocket<SSL>(args);
         if (ws) {
@@ -236,7 +232,7 @@ struct WebSocketWrapper {
 
     /* Takes message, isBinary, compressed. Returns true on success, false otherwise */
     template <bool SSL>
-    static void uWS_WebSocket_send(const FunctionCallbackInfo<Value> &args) {
+    void uWS_WebSocket_send(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *ws = getWebSocket<SSL>(args);
         if (ws) {
@@ -257,7 +253,7 @@ struct WebSocketWrapper {
 
     /* Takes topic string, returns bool */
     template <bool SSL>
-    static void uWS_WebSocket_isSubscribed(const FunctionCallbackInfo<Value> &args) {
+    void uWS_WebSocket_isSubscribed(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *ws = getWebSocket<SSL>(args);
         if (ws) {
@@ -274,7 +270,7 @@ struct WebSocketWrapper {
 
     /* Takes message. Returns true on success, false otherwise */
     template <bool SSL>
-    static void uWS_WebSocket_ping(const FunctionCallbackInfo<Value> &args) {
+    void uWS_WebSocket_ping(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *ws = getWebSocket<SSL>(args);
         if (ws) {
@@ -292,7 +288,7 @@ struct WebSocketWrapper {
 
     /* Takes function, returns this */
     template <bool SSL>
-    static void uWS_WebSocket_cork(const FunctionCallbackInfo<Value> &args) {
+    void uWS_WebSocket_cork(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *ws = getWebSocket<SSL>(args);
         if (ws) {
@@ -308,7 +304,7 @@ struct WebSocketWrapper {
 
     /* This one is wrapped instead of iterateTopics as JS-people will put their hands in wood chipper for sure. */
     template <bool SSL>
-    static void uWS_WebSocket_getTopics(const FunctionCallbackInfo<Value> &args) {
+    void uWS_WebSocket_getTopics(args_t args) {
         Isolate *isolate = args.GetIsolate();
         auto *ws = getWebSocket<SSL>(args);
         if (ws) {
@@ -332,7 +328,7 @@ struct WebSocketWrapper {
 
 // Version A: Handles Strings
 template <bool SSL>
-static uint32_t uWS_WebSocket_send_fast_string(v8::Local<v8::Object> receiver, 
+uint32_t uWS_WebSocket_send_fast_string(v8::Local<v8::Object> receiver, 
                                                const v8::FastOneByteString& message, 
                                                bool isBinary, bool compress) {
     auto *ws = (uWS::WebSocket<SSL, true, PerSocketData> *) receiver->GetAlignedPointerFromInternalField(0);
@@ -343,7 +339,7 @@ static uint32_t uWS_WebSocket_send_fast_string(v8::Local<v8::Object> receiver,
 
 // Version B: Handles ArrayBuffer/TypedArray
 template <bool SSL>
-static uint32_t uWS_WebSocket_send_fast_buffer(v8::Local<v8::Object> receiver, 
+uint32_t uWS_WebSocket_send_fast_buffer(v8::Local<v8::Object> receiver, 
                                                v8::Local<v8::Value> message, 
                                                bool isBinary, bool compress) {
     auto *ws = (uWS::WebSocket<SSL, true, PerSocketData> *) receiver->GetAlignedPointerFromInternalField(0);
@@ -369,39 +365,50 @@ static uint32_t uWS_WebSocket_send_fast_buffer(v8::Local<v8::Object> receiver,
                     isBinary ? uWS::OpCode::BINARY : uWS::OpCode::TEXT, compress);
 }
 
-    template <bool SSL>
-    static Local<Object> init(Isolate *isolate) {
+    template <bool SSLOption>
+    Local<Object> init(Isolate *isolate) {
         Local<FunctionTemplate> wsTemplateLocal = FunctionTemplate::New(isolate);
-        if (SSL) {
-            wsTemplateLocal->SetClassName(String::NewFromUtf8(isolate, "uWS.SSLWebSocket", NewStringType::kNormal).ToLocalChecked());
-        } else {
-            wsTemplateLocal->SetClassName(String::NewFromUtf8(isolate, "uWS.WebSocket", NewStringType::kNormal).ToLocalChecked());
-        }
+        
+        wsTemplateLocal->SetClassName(String::NewFromUtf8(isolate, SSLOption == 1 ? "uWS.SSLWebSocket" : "uWS.WebSocket", NewStringType::kNormal).ToLocalChecked());
+
         wsTemplateLocal->InstanceTemplate()->SetInternalFieldCount(1);
 
-        /* Register our functions */
-        wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "sendFirstFragment", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_sendFirstFragment<SSL>));
-        wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "sendFragment", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_sendFragment<SSL>));
-        wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "sendLastFragment", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_sendLastFragment<SSL>));
+        /* helper */
+        auto regFn = [wsObjectTemplate = wsTemplateLocal->PrototypeTemplate(), isolate]<size_t N>(
+          const char (&str)[N],
+          void(*cb)(args_t)
+        ){
+          wsObjectTemplate->Set(
+            String::NewFromUtf8(isolate, str, NewStringType::kNormal, N-1).ToLocalChecked(),
+            FunctionTemplate::New(isolate, cb)
+          );
+        };
 
-        wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getUserData", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_getUserData<SSL>));
-        static v8::CFunction fast_send = v8::CFunction::Make(uWS_WebSocket_send_fast_buffer<SSL>);
-        wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "send", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_send<SSL>/*, Local<Value>(), Local<Signature>(), 0, ConstructorBehavior::kThrow, SideEffectType::kHasSideEffect, &fast_send*/));
-        wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "end", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_end<SSL>));
-        wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "close", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_close<SSL>));
-        wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getBufferedAmount", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_getBufferedAmount<SSL>));
-        wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getRemoteAddress", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_getRemoteAddress<SSL>));
-        wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "subscribe", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_subscribe<SSL>));
-        wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "unsubscribe", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_unsubscribe<SSL>));
-        wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "publish", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_publish<SSL>));
-        wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "cork", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_cork<SSL>));
-        wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "ping", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_ping<SSL>));
-        wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getRemoteAddressAsText", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_getRemoteAddressAsText<SSL>));
-        wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getRemotePort", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_getRemotePort<SSL>));
-        wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "isSubscribed", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_isSubscribed<SSL>));
+        /* Register our functions */
+        regFn("sendFirstFragment", uWS_WebSocket_sendFirstFragment<SSLOption>);
+        regFn("sendFragment", uWS_WebSocket_sendFragment<SSLOption>);
+        regFn("sendLastFragment", uWS_WebSocket_sendLastFragment<SSLOption>);
+
+        regFn("getUserData", uWS_WebSocket_getUserData);
+
+        static v8::CFunction fast_send = v8::CFunction::Make(uWS_WebSocket_send_fast_buffer<SSLOption>);
+
+        regFn("send", uWS_WebSocket_send<SSLOption>/*, Local<Value>(), Local<Signature>(), 0, ConstructorBehavior::kThrow, SideEffectType::kHasSideEffect, &fast_send*/);
+        regFn("end", uWS_WebSocket_end<SSLOption>);
+        regFn("close", uWS_WebSocket_close<SSLOption>);
+        regFn("getBufferedAmount", uWS_WebSocket_getBufferedAmount<SSLOption>);
+        regFn("getRemoteAddress", uWS_WebSocket_getRemoteAddress<SSLOption>);
+        regFn("subscribe", uWS_WebSocket_subscribe<SSLOption>);
+        regFn("unsubscribe", uWS_WebSocket_unsubscribe<SSLOption>);
+        regFn("publish", uWS_WebSocket_publish<SSLOption>);
+        regFn("cork", uWS_WebSocket_cork<SSLOption>);
+        regFn("ping", uWS_WebSocket_ping<SSLOption>);
+        regFn("getRemoteAddressAsText", uWS_WebSocket_getRemoteAddressAsText<SSLOption>);
+        regFn("getRemotePort", uWS_WebSocket_getRemotePort<SSLOption>);
+        regFn("isSubscribed", uWS_WebSocket_isSubscribed<SSLOption>);
 
         /* This one does not exist in C++ */
-        wsTemplateLocal->PrototypeTemplate()->Set(String::NewFromUtf8(isolate, "getTopics", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_WebSocket_getTopics<SSL>));
+        regFn("getTopics", uWS_WebSocket_getTopics<SSLOption>);
 
         /* Create the template */
         Local<Object> wsObjectLocal = wsTemplateLocal->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()->NewInstance(isolate->GetCurrentContext()).ToLocalChecked();

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -16,15 +16,11 @@
  */
 
 /* We are only allowed to depend on µWS and V8 in this layer. */
-#include "App.h"
-#include "Http3App.h"
+
 
 #include <iostream>
 #include <vector>
 #include <type_traits>
-
-#include <v8.h>
-using namespace v8;
 
 #include "Utilities.h"
 #include "WebSocketWrapper.h"
@@ -42,7 +38,7 @@ using namespace v8;
 /* This function is somewhat of a simplifying wrapper that does not follow the C++ library.
  * It takes a POST:ed body and contentType, and returns an array of parts if
  * the request is a multipart request */
-void uWS_getParts(const FunctionCallbackInfo<Value> &args) {
+void uWS_getParts(args_t args) {
 
     /* Because we mutate the strings, it is important that we get mutable input like
      * ArrayBuffer or Buffer, not String! */
@@ -115,7 +111,7 @@ void uWS_getParts(const FunctionCallbackInfo<Value> &args) {
 
 //UniquePersistent<Function> timerCallbacksJS[1000];
 
-void uWS_arm(const FunctionCallbackInfo<Value> &args) {
+void uWS_arm(args_t args) {
 
     /* integer */
 
@@ -125,7 +121,7 @@ void uWS_arm(const FunctionCallbackInfo<Value> &args) {
     //unsigned int timer = setTimeout_(nullptr, 1000);
 }
 
-void uWS_setTimeout(const FunctionCallbackInfo<Value> &args) {
+void uWS_setTimeout(args_t args) {
 
     /* Function, integer */
 
@@ -136,7 +132,7 @@ void uWS_setTimeout(const FunctionCallbackInfo<Value> &args) {
     //args.GetReturnValue().Set(Integer::New(args.GetIsolate(), timer));
 }
 
-void uWS_clearTimeout(const FunctionCallbackInfo<Value> &args) {
+void uWS_clearTimeout(args_t args) {
 
     /* Integer */
 
@@ -148,7 +144,7 @@ void uWS_clearTimeout(const FunctionCallbackInfo<Value> &args) {
 }
 
 /* Pass various undocumented configs */
-void uWS_cfg(const FunctionCallbackInfo<Value> &args) {
+void uWS_cfg(args_t args) {
     NativeString key(args.GetIsolate(), args[0]);
     if (key.isInvalid(args)) {
         return;
@@ -161,12 +157,12 @@ void uWS_cfg(const FunctionCallbackInfo<Value> &args) {
 }
 
 /* todo: Put this function and all inits of it in its own header */
-void uWS_us_listen_socket_close(const FunctionCallbackInfo<Value> &args) {
+void uWS_us_listen_socket_close(args_t args) {
     // this should take int ssl first
     us_listen_socket_close(0, (struct us_listen_socket_t *) External::Cast(*args[0])->Value());
 }
 
-void uWS_us_socket_local_port(const FunctionCallbackInfo<Value> &args) {
+void uWS_us_socket_local_port(args_t args) {
     // this should take int ssl first, but us_socket_local_port doesn't use it so it doesn't matter
     int port = us_socket_local_port(0, (struct us_socket_t *) External::Cast(*args[0])->Value());
     args.GetReturnValue().Set(Integer::New(args.GetIsolate(), port));
@@ -182,7 +178,7 @@ std::unordered_map<std::string, std::unordered_map<std::string, uint32_t>> kvSto
 std::mutex kvMutex;
 
 // getString(key, collection)
-void uWS_getString(const FunctionCallbackInfo<Value> &args) {
+void uWS_getString(args_t args) {
     NativeString key(args.GetIsolate(), args[0]);
     if (key.isInvalid(args)) {
         return;
@@ -198,7 +194,7 @@ void uWS_getString(const FunctionCallbackInfo<Value> &args) {
     args.GetReturnValue().Set(String::NewFromUtf8(args.GetIsolate(), value.data(), NewStringType::kNormal, value.length()).ToLocalChecked());
 }
 
-void uWS_setString(const FunctionCallbackInfo<Value> &args) {
+void uWS_setString(args_t args) {
     NativeString key(args.GetIsolate(), args[0]);
     if (key.isInvalid(args)) {
         return;
@@ -216,7 +212,7 @@ void uWS_setString(const FunctionCallbackInfo<Value> &args) {
     kvStoreString[std::string(collection.getString())][std::string(key.getString())] = value.getString();
 }
 
-void uWS_getInteger(const FunctionCallbackInfo<Value> &args) {
+void uWS_getInteger(args_t args) {
     NativeString key(args.GetIsolate(), args[0]);
     if (key.isInvalid(args)) {
         return;
@@ -232,7 +228,7 @@ void uWS_getInteger(const FunctionCallbackInfo<Value> &args) {
     args.GetReturnValue().Set(Integer::New(args.GetIsolate(), value));
 }
 
-void uWS_setInteger(const FunctionCallbackInfo<Value> &args) {
+void uWS_setInteger(args_t args) {
     NativeString key(args.GetIsolate(), args[0]);
     if (key.isInvalid(args)) {
         return;
@@ -248,7 +244,7 @@ void uWS_setInteger(const FunctionCallbackInfo<Value> &args) {
     kvStoreInteger[std::string(collection.getString())][std::string(key.getString())] = value;
 }
 
-void uWS_incInteger(const FunctionCallbackInfo<Value> &args) {
+void uWS_incInteger(args_t args) {
     NativeString key(args.GetIsolate(), args[0]);
     if (key.isInvalid(args)) {
         return;
@@ -267,7 +263,7 @@ void uWS_incInteger(const FunctionCallbackInfo<Value> &args) {
 }
 
 /* This one will spike memory usage for large stores */
-void uWS_getStringKeys(const FunctionCallbackInfo<Value> &args) {
+void uWS_getStringKeys(args_t args) {
 
     NativeString collection(args.GetIsolate(), args[0]);
     if (collection.isInvalid(args)) {
@@ -285,7 +281,7 @@ void uWS_getStringKeys(const FunctionCallbackInfo<Value> &args) {
     args.GetReturnValue().Set(stringKeys);
 }
 
-void uWS_getIntegerKeys(const FunctionCallbackInfo<Value> &args) {
+void uWS_getIntegerKeys(args_t args) {
 
     NativeString collection(args.GetIsolate(), args[0]);
     if (collection.isInvalid(args)) {
@@ -303,7 +299,7 @@ void uWS_getIntegerKeys(const FunctionCallbackInfo<Value> &args) {
     args.GetReturnValue().Set(integerKeys);
 }
 
-void uWS_deleteString(const FunctionCallbackInfo<Value> &args) {
+void uWS_deleteString(args_t args) {
 
     NativeString key(args.GetIsolate(), args[0]);
     if (key.isInvalid(args)) {
@@ -320,7 +316,7 @@ void uWS_deleteString(const FunctionCallbackInfo<Value> &args) {
     //args.GetReturnValue().Set(Integer::New(args.GetIsolate(), value));
 }
 
-void uWS_deleteInteger(const FunctionCallbackInfo<Value> &args) {
+void uWS_deleteInteger(args_t args) {
 
     NativeString key(args.GetIsolate(), args[0]);
     if (key.isInvalid(args)) {
@@ -337,7 +333,7 @@ void uWS_deleteInteger(const FunctionCallbackInfo<Value> &args) {
     //args.GetReturnValue().Set(Integer::New(args.GetIsolate(), value));
 }
 
-void uWS_deleteStringCollection(const FunctionCallbackInfo<Value> &args) {
+void uWS_deleteStringCollection(args_t args) {
 
     NativeString collection(args.GetIsolate(), args[0]);
     if (collection.isInvalid(args)) {
@@ -349,7 +345,7 @@ void uWS_deleteStringCollection(const FunctionCallbackInfo<Value> &args) {
     //args.GetReturnValue().Set(integerKeys);
 }
 
-void uWS_deleteIntegerCollection(const FunctionCallbackInfo<Value> &args) {
+void uWS_deleteIntegerCollection(args_t args) {
 
     NativeString collection(args.GetIsolate(), args[0]);
     if (collection.isInvalid(args)) {
@@ -361,94 +357,117 @@ void uWS_deleteIntegerCollection(const FunctionCallbackInfo<Value> &args) {
     //args.GetReturnValue().Set(integerKeys);
 }
 
-void uWS_lock(const FunctionCallbackInfo<Value> &args) {
+void uWS_lock(args_t args) {
     kvMutex.lock();
 }
 
-void uWS_unlock(const FunctionCallbackInfo<Value> &args) {
+void uWS_unlock(args_t args) {
     kvMutex.unlock();
 }
 
-PerContextData *Main(Local<Object> exports) {
+PerIsolateData *Main(Local<Object> exports) {
 
     /* We pass isolate everywhere */
     Isolate *isolate = exports->GetIsolate();
-
+    Local<Context> context = isolate->GetCurrentContext();
     /* Init the template objects, SSL and non-SSL, store it in per context data */
-    PerContextData *perContextData = new PerContextData;
-    perContextData->isolate = isolate;
-    perContextData->reqTemplate[0].Reset(isolate, HttpRequestWrapper::init<false>(isolate));
-    perContextData->reqTemplate[1].Reset(isolate, HttpRequestWrapper::init<true>(isolate));
-    perContextData->resTemplate[0].Reset(isolate, HttpResponseWrapper::init<0>(isolate));
-    perContextData->resTemplate[1].Reset(isolate, HttpResponseWrapper::init<1>(isolate));
-    perContextData->resTemplate[2].Reset(isolate, HttpResponseWrapper::init<2>(isolate));
-    perContextData->resTemplate[3].Reset(isolate, HttpResponseWrapper::init<3>(isolate));
-    perContextData->wsTemplate[0].Reset(isolate, WebSocketWrapper::init<0>(isolate));
-    perContextData->wsTemplate[1].Reset(isolate, WebSocketWrapper::init<1>(isolate));
+    PerIsolateData *perIsolateData = new PerIsolateData;
+    perIsolateData->isolate = isolate;
+    perIsolateData->reqTemplate[0].Reset(isolate, HttpRequestWrapper::init<0>(isolate));
+    perIsolateData->reqTemplate[1].Reset(isolate, HttpRequestWrapper::init<2>(isolate));
+    perIsolateData->resTemplate[0].Reset(isolate, HttpResponseWrapper::init<0>(isolate));
+    perIsolateData->resTemplate[1].Reset(isolate, HttpResponseWrapper::init<1>(isolate));
+    perIsolateData->resTemplate[2].Reset(isolate, HttpResponseWrapper::init<2>(isolate));
+    perIsolateData->resTemplate[3].Reset(isolate, HttpResponseWrapper::init<3>(isolate));
+    perIsolateData->wsTemplate[0].Reset(isolate, WebSocketWrapper::init<0>(isolate));
+    perIsolateData->wsTemplate[1].Reset(isolate, WebSocketWrapper::init<1>(isolate));
 
     /* Refer to per context data via External */
-    Local<External> externalPerContextData = External::New(isolate, perContextData);
+    Local<External> externalPerContextData = External::New(isolate, perIsolateData);
+
+    /* Helpers to write almost NOTHING manually */
+    auto regFn = [=]<size_t N>(
+      const char (&str)[N],
+      void(*cb)(args_t)
+    ){
+      exports->Set(
+        context,
+        String::NewFromUtf8(isolate, str, NewStringType::kNormal, N-1).ToLocalChecked(),
+        FunctionTemplate::New(isolate, cb, externalPerContextData)->GetFunction(context).ToLocalChecked()
+      ).ToChecked();
+    };
+    auto regNum = [=]<size_t N>(
+      const char (&str)[N],
+      uint32_t number
+    ){
+      exports->Set(
+        context,
+        String::NewFromUtf8(isolate, str, NewStringType::kNormal, N-1).ToLocalChecked(),
+        Integer::NewFromUnsigned(isolate, number)
+      ).ToChecked();
+    };
 
     /* uWS namespace */
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "App", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_App<uWS::App>, externalPerContextData)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "SSLApp", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_App<uWS::SSLApp>, externalPerContextData)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
-
+    regFn("App", uWS_App<uWS::App>);
+    regFn("SSLApp", uWS_App<uWS::SSLApp>);
+    
     /* H3 experimental */
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "H3App", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_App<uWS::H3App>, externalPerContextData)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
+    regFn("H3App", uWS_App<uWS::H3App>);
 
     /* Temporary KV store */
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "getString", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_getString)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "setString", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_setString)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "getInteger", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_getInteger)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "setInteger", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_setInteger)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "incInteger", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_incInteger)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "lock", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_lock)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "unlock", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_unlock)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "getIntegerKeys", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_getIntegerKeys)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "getStringKeys", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_getStringKeys)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "deleteString", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_deleteString)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "deleteInteger", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_deleteInteger)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "deleteStringCollection", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_deleteStringCollection)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "deleteIntegerCollection", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_deleteIntegerCollection)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
+    
+    regFn("getString",  uWS_getString);
+    regFn("setString",  uWS_setString);
+    regFn("getInteger",  uWS_getInteger);
+    regFn("setInteger",  uWS_setInteger);
+    regFn("incInteger",  uWS_incInteger);
+    regFn("lock",  uWS_lock);
+    regFn("unlock",  uWS_unlock);
+    regFn("getIntegerKeys",  uWS_getIntegerKeys);
+    regFn("getStringKeys",  uWS_getStringKeys);
+    regFn("deleteString",  uWS_deleteString);
+    regFn("deleteInteger",  uWS_deleteInteger);
+    regFn("deleteStringCollection",  uWS_deleteStringCollection);
+    regFn("deleteIntegerCollection",  uWS_deleteIntegerCollection);
 
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "setTimeout", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_setTimeout)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "clearTimeout", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_clearTimeout)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "arm", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_arm)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
+    regFn("setTimeout",  uWS_setTimeout);
+    regFn("clearTimeout",  uWS_clearTimeout);
+    regFn("arm",  uWS_arm);
 
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "_cfg", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_cfg)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "getParts", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_getParts)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
+    regFn("_cfg",  uWS_cfg);
+    regFn("getParts",  uWS_getParts);
     
     /* Expose some µSockets functions directly under uWS namespace */
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "us_listen_socket_close", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_us_listen_socket_close)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "us_socket_local_port", NewStringType::kNormal).ToLocalChecked(), FunctionTemplate::New(isolate, uWS_us_socket_local_port)->GetFunction(isolate->GetCurrentContext()).ToLocalChecked()).ToChecked();
+    regFn("us_listen_socket_close",  uWS_us_listen_socket_close);
+    regFn("us_socket_local_port",  uWS_us_socket_local_port);
 
     /* Compression enum */
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "DISABLED", NewStringType::kNormal).ToLocalChecked(), Integer::NewFromUnsigned(isolate, uWS::DISABLED)).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "SHARED_COMPRESSOR", NewStringType::kNormal).ToLocalChecked(), Integer::NewFromUnsigned(isolate, uWS::SHARED_COMPRESSOR)).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "SHARED_DECOMPRESSOR", NewStringType::kNormal).ToLocalChecked(), Integer::NewFromUnsigned(isolate, uWS::SHARED_DECOMPRESSOR)).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "DEDICATED_DECOMPRESSOR", NewStringType::kNormal).ToLocalChecked(), Integer::NewFromUnsigned(isolate, uWS::DEDICATED_DECOMPRESSOR)).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "DEDICATED_COMPRESSOR", NewStringType::kNormal).ToLocalChecked(), Integer::NewFromUnsigned(isolate, uWS::DEDICATED_COMPRESSOR)).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "DEDICATED_COMPRESSOR_3KB", NewStringType::kNormal).ToLocalChecked(), Integer::NewFromUnsigned(isolate, uWS::DEDICATED_COMPRESSOR_3KB)).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "DEDICATED_COMPRESSOR_4KB", NewStringType::kNormal).ToLocalChecked(), Integer::NewFromUnsigned(isolate, uWS::DEDICATED_COMPRESSOR_4KB)).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "DEDICATED_COMPRESSOR_8KB", NewStringType::kNormal).ToLocalChecked(), Integer::NewFromUnsigned(isolate, uWS::DEDICATED_COMPRESSOR_8KB)).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "DEDICATED_COMPRESSOR_16KB", NewStringType::kNormal).ToLocalChecked(), Integer::NewFromUnsigned(isolate, uWS::DEDICATED_COMPRESSOR_16KB)).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "DEDICATED_COMPRESSOR_32KB", NewStringType::kNormal).ToLocalChecked(), Integer::NewFromUnsigned(isolate, uWS::DEDICATED_COMPRESSOR_32KB)).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "DEDICATED_COMPRESSOR_64KB", NewStringType::kNormal).ToLocalChecked(), Integer::NewFromUnsigned(isolate, uWS::DEDICATED_COMPRESSOR_64KB)).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "DEDICATED_COMPRESSOR_128KB", NewStringType::kNormal).ToLocalChecked(), Integer::NewFromUnsigned(isolate, uWS::DEDICATED_COMPRESSOR_128KB)).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "DEDICATED_COMPRESSOR_256KB", NewStringType::kNormal).ToLocalChecked(), Integer::NewFromUnsigned(isolate, uWS::DEDICATED_COMPRESSOR_256KB)).ToChecked();
+    regNum("DISABLED", uWS::DISABLED);
+    regNum("SHARED_COMPRESSOR", uWS::SHARED_COMPRESSOR);
+    regNum("SHARED_DECOMPRESSOR", uWS::SHARED_DECOMPRESSOR);
+    regNum("DEDICATED_DECOMPRESSOR", uWS::DEDICATED_DECOMPRESSOR);
+    regNum("DEDICATED_COMPRESSOR", uWS::DEDICATED_COMPRESSOR);
+    regNum("DEDICATED_COMPRESSOR_3KB", uWS::DEDICATED_COMPRESSOR_3KB);
+    regNum("DEDICATED_COMPRESSOR_4KB", uWS::DEDICATED_COMPRESSOR_4KB);
+    regNum("DEDICATED_COMPRESSOR_8KB", uWS::DEDICATED_COMPRESSOR_8KB);
+    regNum("DEDICATED_COMPRESSOR_16KB", uWS::DEDICATED_COMPRESSOR_16KB);
+    regNum("DEDICATED_COMPRESSOR_32KB", uWS::DEDICATED_COMPRESSOR_32KB);
+    regNum("DEDICATED_COMPRESSOR_64KB", uWS::DEDICATED_COMPRESSOR_64KB);
+    regNum("DEDICATED_COMPRESSOR_128KB", uWS::DEDICATED_COMPRESSOR_128KB);
+    regNum("DEDICATED_COMPRESSOR_256KB", uWS::DEDICATED_COMPRESSOR_256KB);
 
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "DEDICATED_DECOMPRESSOR_32KB", NewStringType::kNormal).ToLocalChecked(), Integer::NewFromUnsigned(isolate, uWS::DEDICATED_DECOMPRESSOR_32KB)).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "DEDICATED_DECOMPRESSOR_16KB", NewStringType::kNormal).ToLocalChecked(), Integer::NewFromUnsigned(isolate, uWS::DEDICATED_DECOMPRESSOR_16KB)).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "DEDICATED_DECOMPRESSOR_8KB", NewStringType::kNormal).ToLocalChecked(), Integer::NewFromUnsigned(isolate, uWS::DEDICATED_DECOMPRESSOR_8KB)).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "DEDICATED_DECOMPRESSOR_4KB", NewStringType::kNormal).ToLocalChecked(), Integer::NewFromUnsigned(isolate, uWS::DEDICATED_DECOMPRESSOR_4KB)).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "DEDICATED_DECOMPRESSOR_2KB", NewStringType::kNormal).ToLocalChecked(), Integer::NewFromUnsigned(isolate, uWS::DEDICATED_DECOMPRESSOR_2KB)).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "DEDICATED_DECOMPRESSOR_1KB", NewStringType::kNormal).ToLocalChecked(), Integer::NewFromUnsigned(isolate, uWS::DEDICATED_DECOMPRESSOR_1KB)).ToChecked();
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "DEDICATED_DECOMPRESSOR_512B", NewStringType::kNormal).ToLocalChecked(), Integer::NewFromUnsigned(isolate, uWS::DEDICATED_DECOMPRESSOR_512B)).ToChecked();
+    regNum("DEDICATED_DECOMPRESSOR_32KB", uWS::DEDICATED_DECOMPRESSOR_32KB);
+    regNum("DEDICATED_DECOMPRESSOR_16KB", uWS::DEDICATED_DECOMPRESSOR_16KB);
+    regNum("DEDICATED_DECOMPRESSOR_8KB", uWS::DEDICATED_DECOMPRESSOR_8KB);
+    regNum("DEDICATED_DECOMPRESSOR_4KB", uWS::DEDICATED_DECOMPRESSOR_4KB);
+    regNum("DEDICATED_DECOMPRESSOR_2KB", uWS::DEDICATED_DECOMPRESSOR_2KB);
+    regNum("DEDICATED_DECOMPRESSOR_1KB", uWS::DEDICATED_DECOMPRESSOR_1KB);
+    regNum("DEDICATED_DECOMPRESSOR_512B", uWS::DEDICATED_DECOMPRESSOR_512B);
 
     /* Listen options */
-    exports->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "LIBUS_LISTEN_EXCLUSIVE_PORT", NewStringType::kNormal).ToLocalChecked(), Integer::NewFromUnsigned(isolate, LIBUS_LISTEN_EXCLUSIVE_PORT)).ToChecked();
+    regNum("LIBUS_LISTEN_EXCLUSIVE_PORT", LIBUS_LISTEN_EXCLUSIVE_PORT);
 
-    return perContextData;
+    return perIsolateData;
 }
 
 /* This is required when building as a Node.js addon */
@@ -459,22 +478,22 @@ NODE_MODULE_INITIALIZER(Local<Object> exports, Local<Value> module, Local<Contex
     /* Integrate uSockets with existing libuv loop */
     uWS::Loop::get(node::GetCurrentEventLoop(context->GetIsolate()));
     /* Register vanilla V8 addon */
-    PerContextData *perContextData = Main(exports);
+    PerIsolateData *perIsolateData = Main(exports);
 
     /* We cannot rely on process.exit or process.beforeExit when it comes to WorkerThreads */
     node::AddEnvironmentCleanupHook(context->GetIsolate(), [](void *arg) {
 
-        PerContextData *perContextData = (PerContextData *) arg;
+        PerIsolateData *perIsolateData = (PerIsolateData *) arg;
 
         /* Freeing apps here, it could be done earlier but not sooner */
-        perContextData->apps.clear();
-        perContextData->sslApps.clear();
+        perIsolateData->apps.clear();
+        perIsolateData->sslApps.clear();
         /* Freeing the loop here means we give time for our timers to close, etc */
         uWS::Loop::get()->free();
 
         /* We can safely delete this since we no longer can call uWS.free */
-        delete perContextData;
+        delete perIsolateData;
 
-    }, perContextData);
+    }, perIsolateData);
 }
 #endif


### PR DESCRIPTION
As the name suggests, why suffer? I did following changes for DX within C++ codebase:

Made Utilities.h central header-file (clangd LSP sees Http3 functonality in every file). Basically I put `#include <v8.h> #include "App.h" #include "Http3App.h" using namespace v8` into Utilities.h; 

renamed PerContextData to PerIsolateData. In fact, this struct is local to each V8 instance, which is Isolate. If it is "per isolate", why not be "PerIsolateData" ?; 

replaced 'const FunctionCallbackInfo<Value>&' onto 'args_t'. Name is self-explanatory (type for arguments), much easier to write; 

reduced boilerplate in 'init' functions. I put registering functionality into lambdas, so they don't live on the global stack and this saves tons of effort when trying to figure out what code does.

So while I have a draft for build improvements, I have also made a draft for C++ DX + type-safety (coming in subsequent PRs). This is the first pull request. Again, it compiles with old build and with build.exe from my other pull-request.