### PR TITLE
Made Utilities.h central header-file with includes of v8.h + uWS

### DIFF
--- a/src/AppWrapper.h
+++ b/src/AppWrapper.h
@@ -15,10 +15,7 @@
  * limitations under the License.
  */
 
-#include "App.h"
-#include <v8.h>
 #include "Utilities.h"
-using namespace v8;
 
 /* uWS.App.ws('/pattern', behavior) */
 template <typename APP>

--- a/src/HttpRequestWrapper.h
+++ b/src/HttpRequestWrapper.h
@@ -15,11 +15,8 @@
  * limitations under the License.
  */
 
-#include "App.h"
 #include "Utilities.h"
 
-#include <v8.h>
-using namespace v8;
 
 /* This one is the same for SSL and non-SSL */
 struct HttpRequestWrapper {

--- a/src/HttpResponseWrapper.h
+++ b/src/HttpResponseWrapper.h
@@ -15,11 +15,7 @@
  * limitations under the License.
  */
 
-#include "App.h"
 #include "Utilities.h"
-
-#include <v8.h>
-using namespace v8;
 
 thread_local int insideCorkCallback = 0;
 

--- a/src/Utilities.h
+++ b/src/Utilities.h
@@ -23,6 +23,10 @@
 #include <v8.h>
 using namespace v8;
 
+// Utilities.h are included once due to ADDON_UTILITIES_H, so let it be a central header-file
+#include "App.h"
+#include "Http3App.h"
+
 /* Unfortunately we _have_ to depend on Node.js crap */
 #include <node.h>
 

--- a/src/WebSocketWrapper.h
+++ b/src/WebSocketWrapper.h
@@ -15,12 +15,9 @@
  * limitations under the License.
  */
 
-#include "App.h"
 #include "Utilities.h"
 
-#include <v8.h>
 #include "v8-fast-api-calls.h"
-using namespace v8;
 
 /* todo: probably isCorked, cork should be exposed? */
 

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -15,17 +15,10 @@
  * limitations under the License.
  */
 
-/* We are only allowed to depend on µWS and V8 in this layer. */
-#include "App.h"
-#include "Http3App.h"
 
 #include <iostream>
 #include <vector>
 #include <type_traits>
-
-#include <v8.h>
-using namespace v8;
-
 #include "Utilities.h"
 #include "WebSocketWrapper.h"
 #include "HttpResponseWrapper.h"


### PR DESCRIPTION
Http3App.h headerfile in uWS doesn't have any macro checks to verify if it was already included, like Utilities.h. To address this I put Http3App.h include into Utilities.h. Considering its presence in every other file, I put repeated App.h there as well and removed unnecessary `#include <v8.h>` from every file, apart from Utilities.h. 

This way Utilities.h provides codebase with LSP support, eliminating risk of re-including unprotected Http3App.h