### PR TITLE
fix NativeString encoding bug

### DIFF
--- a/src/HttpRequestWrapper.h
+++ b/src/HttpRequestWrapper.h
@@ -71,7 +71,7 @@ struct HttpRequestWrapper {
                 int index = args[0]->Uint32Value(isolate->GetCurrentContext()).ToChecked();
                 parameter = req->getParameter(index);
             } else {
-                NativeString<true> data(args.GetIsolate(), args[0]);
+                NativeString data(args.GetIsolate(), args[0]);
                 if (data.isInvalid(args)) {
                     return;
                 }
@@ -100,7 +100,7 @@ struct HttpRequestWrapper {
         Isolate *isolate = args.GetIsolate();
         auto *req = getHttpRequest<QUIC>(args);
         if (req) {
-            NativeString<true> data(args.GetIsolate(), args[0]);
+            NativeString data(args.GetIsolate(), args[0]);
             if (data.isInvalid(args)) {
                 return;
             }
@@ -158,7 +158,7 @@ struct HttpRequestWrapper {
 
             /* Do we have a key argument? */
             if (args.Length() == 1) {
-                NativeString<true> keyString(isolate, args[0]);
+                NativeString keyString(isolate, args[0]);
                 if (keyString.isInvalid(args)) {
                     return;
                 }

--- a/src/HttpResponseWrapper.h
+++ b/src/HttpResponseWrapper.h
@@ -369,7 +369,7 @@ struct HttpResponseWrapper {
     static void res_writeStatus(const FunctionCallbackInfo<Value> &args) {
         auto *res = getHttpResponse<SSL>(args);
             if (res) {
-            NativeString<true> data(args.GetIsolate(), args[0]);
+            NativeString data(args.GetIsolate(), args[0]);
             if (data.isInvalid(args)) {
                 return;
             }
@@ -409,7 +409,7 @@ struct HttpResponseWrapper {
     static void res_end(const FunctionCallbackInfo<Value> &args) {
         auto *res = getHttpResponse<PROTOCOL>(args);
         if (res) {
-            NativeString<true> data(args.GetIsolate(), args[0]);
+            NativeString data(args.GetIsolate(), args[0]);
             if (data.isInvalid(args)) {
                 return;
             }
@@ -434,7 +434,7 @@ struct HttpResponseWrapper {
         Isolate *isolate = args.GetIsolate();
         auto *res = getHttpResponse<PROTOCOL>(args);
         if (res) {
-            NativeString<true> data(args.GetIsolate(), args[0]);
+            NativeString data(args.GetIsolate(), args[0]);
             if (data.isInvalid(args)) {
                 return;
             }
@@ -467,7 +467,7 @@ struct HttpResponseWrapper {
         Isolate *isolate = args.GetIsolate();
         auto *res = getHttpResponse<PROTOCOL>(args);
         if (res) {
-            NativeString<true> data(args.GetIsolate(), args[0]);
+            NativeString data(args.GetIsolate(), args[0]);
             if (data.isInvalid(args)) {
                 return;
             }
@@ -486,11 +486,11 @@ struct HttpResponseWrapper {
         if (res) {
             // Optimization: writeHeader never calls JS or allocated on the GC
             // use zero copy string view in best case
-            NativeString<true> header(args.GetIsolate(), args[0]);
+            NativeString header(args.GetIsolate(), args[0]);
             if (header.isInvalid(args)) {
                 return;
             }
-            NativeString<true> value(args.GetIsolate(), args[1]);
+            NativeString value(args.GetIsolate(), args[1]);
             if (value.isInvalid(args)) {
                 return;
             }

--- a/src/Utilities.h
+++ b/src/Utilities.h
@@ -118,7 +118,6 @@ struct Callback {
     }
 };
 
-template <bool AllowStringView = false>
 class NativeString {
     char *data;
     size_t length;
@@ -138,11 +137,12 @@ class NativeString {
         if (pool_offset + size > pool.size()) {
             // Mark for external cleanup if using instance-based logic
             // (Note: In a pure static alloc, you'd need a way to track this)
-            return (char*)std::malloc(size);
+            return (char*) std::malloc(size);
         }
 
         char* ptr = pool.data() + pool_offset;
         pool_offset += size;
+        ref_count++;
         return ptr;
     }
 
@@ -150,41 +150,30 @@ class NativeString {
     static void free(char* ptr) {
         if (ptr < pool.data() || ptr >= pool.data() + pool.size()) {
             ::free(ptr);
+        } else if (--ref_count == 0) {
+            // Reset the "stack" once no more reference
+            pool_offset = 0;
         }
     }
 
 public:
     NativeString(Isolate *isolate, const Local<Value> &value) {
-        if (ref_count == 0) {
-            pool_offset = 0; // Reset the "stack" when entering the first scope
-        }
-        ref_count++;
-
         if (value->IsUndefined()) {
             data = nullptr;
             length = 0;
         } else if (value->IsString()) {
             Local<String> string = Local<String>::Cast(value);
-
-            #if NODE_MODULE_VERSION >= 137
-            if constexpr (AllowStringView) {
-
-                String::ValueView strView(isolate, string);
-                if (strView.is_one_byte()) {
-                    length = strView.length();
-                    data = (char *) strView.data8();
-                    
-                    return;
-                }
-            }
+            #if NODE_MODULE_VERSION >= 137 // node >= 24
+                length = string->Utf8LengthV2(isolate);
+                data = alloc(length);
+                allocated = true;
+                string->WriteUtf8V2(isolate, data, length);
+            #else
+                length = string->Utf8Length(isolate);
+                data = alloc(length);
+                allocated = true;
+                string->WriteUtf8(isolate, data, length, nullptr, String::WriteOptions::NO_NULL_TERMINATION);
             #endif
-
-            // Fallback
-            length = string->Utf8Length(isolate);
-            data = alloc(length);
-            allocated = true;
-            string->WriteUtf8(isolate, data, length, nullptr, String::WriteOptions::NO_NULL_TERMINATION);
-
         } else if (value->IsTypedArray()) {
             Local<ArrayBufferView> arrayBufferView = Local<ArrayBufferView>::Cast(value);
             auto contents = arrayBufferView->Buffer()->GetBackingStore();
@@ -217,7 +206,6 @@ public:
     }
 
     ~NativeString() {
-        ref_count--;
         if (allocated) {
             free(data);
         }

--- a/src/WebSocketWrapper.h
+++ b/src/WebSocketWrapper.h
@@ -52,7 +52,7 @@ struct WebSocketWrapper {
         Isolate *isolate = args.GetIsolate();
         auto *ws = getWebSocket<SSL>(args);
         if (ws) {
-            NativeString<true> topic(isolate, args[0]);
+            NativeString topic(isolate, args[0]);
             if (topic.isInvalid(args)) {
                 return;
             }
@@ -67,7 +67,7 @@ struct WebSocketWrapper {
         Isolate *isolate = args.GetIsolate();
         auto *ws = getWebSocket<SSL>(args);
         if (ws) {
-            NativeString<true> topic(isolate, args[0]);
+            NativeString topic(isolate, args[0]);
             if (topic.isInvalid(args)) {
                 return;
             }
@@ -89,11 +89,11 @@ struct WebSocketWrapper {
             bool isBinary = args[2]->BooleanValue(isolate);
             bool compress = args[3]->BooleanValue(isolate);
 
-            NativeString<true> topic(isolate, args[0]);
+            NativeString topic(isolate, args[0]);
             if (topic.isInvalid(args)) {
                 return;
             }
-            NativeString<true> message(isolate, args[1]);
+            NativeString message(isolate, args[1]);
             if (message.isInvalid(args)) {
                 return;
             }
@@ -127,7 +127,7 @@ struct WebSocketWrapper {
                 code = args[0]->Uint32Value(isolate->GetCurrentContext()).ToChecked();
             }
 
-            NativeString<true> message(args.GetIsolate(), args[1]);
+            NativeString message(args.GetIsolate(), args[1]);
             if (message.isInvalid(args)) {
                 return;
             }
@@ -244,7 +244,7 @@ struct WebSocketWrapper {
             bool isBinary = args[1]->BooleanValue(isolate);
             bool compress = args[2]->BooleanValue(isolate);
 
-            NativeString<true> message(args.GetIsolate(), args[0]);
+            NativeString message(args.GetIsolate(), args[0]);
             if (message.isInvalid(args)) {
                 return;
             }
@@ -261,7 +261,7 @@ struct WebSocketWrapper {
         Isolate *isolate = args.GetIsolate();
         auto *ws = getWebSocket<SSL>(args);
         if (ws) {
-            NativeString<true> topic(args.GetIsolate(), args[0]);
+            NativeString topic(args.GetIsolate(), args[0]);
             if (topic.isInvalid(args)) {
                 return;
             }
@@ -278,7 +278,7 @@ struct WebSocketWrapper {
         Isolate *isolate = args.GetIsolate();
         auto *ws = getWebSocket<SSL>(args);
         if (ws) {
-            NativeString<true> message(args.GetIsolate(), args[0]);
+            NativeString message(args.GetIsolate(), args[0]);
             if (message.isInvalid(args)) {
                 return;
             }


### PR DESCRIPTION
Using the `String::ValueView` optimization actually adds an encoding issue (#1280).
Seems like the ValueView gives access to an ISO-8859-1 code points encoded string while we need a utf-8 encoded string.
So it was working for strings having same representation in both encoding but not for the others.

This PR removes de `String::ValueView` optimization and only use the `WriteUtf8()` and `WriteUtf8V2()`.
We loose a bit of performance but not that much thanks to the pool system, it is still much faster than the old Utf8Value copy.

binary: 157k Req/Sec
Utf8Value: 152k Req/Sec
ValueView: 158k Req/Sec
WriteUtf8: 155k Req/Sec
WriteUtf8V2: 156k Req/Sec