### PR TITLE
typedoc: show null and undefined union types

### DIFF
--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"files": [ "index.d.ts" ],
 	"compilerOptions": {
+		"strictNullChecks":true,
 		"lib": [ "es2017" ]
 	},
 	"typedocOptions": {


### PR DESCRIPTION
The current generated docs do not show the `| null` and `| undefined` union types.
For example the [getParameter()](https://unetworking.github.io/uWebSockets.js/generated/interfaces/HttpRequest.html#getparameter) doc is `Returns string` while it should be `Returns string | undefined`.
This PR adds the `strictNullChecks` TS compiler option to force checking and displaying the null and undefined types.