### PR TITLE
Use Docker images to build Linux versions to provide compatibility for older glibc versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,14 +20,6 @@ jobs:
             name: "macOS 15",
             os: macos-15
           }
-        # - {
-        #     name: "Ubuntu 24.04",
-        #     os: ubuntu-24.04
-        #   }
-        # - {
-        #     name: "Ubuntu 24.04 ARM",
-        #     os: ubuntu-24.04-arm
-        #   }
         - {
             name: "Ubuntu 22.04",
             os: ubuntu-latest,
@@ -35,7 +27,7 @@ jobs:
           }
         - {
             name: "Ubuntu 22.04 ARM64",
-            os: ubuntu-latest-arm,
+            os: ubuntu-24.04-arm,
             container_image: "ubuntu:22.04"
           }
 
@@ -102,7 +94,7 @@ jobs:
           ls
           ${{ matrix.config.os != 'windows-latest' && 'git checkout dockerbuild docs/index.d.ts && mv docs/index.d.ts .' || '' }}
           git status
-          git config --global user.email "andreas@gruber.info"
-          git config --global user.name "Andreas Gruber"
+          git config --global user.email "alexhultman@gmail.com"
+          git config --global user.name "Alex Hultman"
           git commit -a -m "[GitHub Actions] Updated ${{ matrix.config.os }} binaries" || true
-          git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/andygruber/uWebSockets.js" binaries
+          git push "https://andygruber:${{ secrets.SECRET }}@github.com/andygruber/uWebSockets.js" binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,22 +12,22 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - {
-            name: "Windows Latest",
-            os: windows-latest
-          }
-        - {
-            name: "macOS 15",
-            os: macos-15
-          }
+        # - {
+        #     name: "Windows Latest",
+        #     os: windows-latest
+        #   }
+        # - {
+        #     name: "macOS 15",
+        #     os: macos-15
+        #   }
         # - {
         #     name: "Ubuntu 24.04",
         #     os: ubuntu-24.04
         #   }
-        - {
-            name: "Ubuntu 24.04 ARM",
-            os: ubuntu-24.04-arm
-          }
+        # - {
+        #     name: "Ubuntu 24.04 ARM",
+        #     os: ubuntu-24.04-arm
+        #   }
         - {
             name: "Debian Bookworm",
             os: ubuntu-latest,
@@ -50,7 +50,7 @@ jobs:
         if: matrix.config.container_image != null
         run: |
           apt-get update
-          apt-get install -y build-essential git libssl-dev file zip curl jq
+          apt-get install -y build-essential git libssl-dev file zip curl jq cmake clang
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,14 +21,14 @@ jobs:
             os: macos-15
           }
         - {
-            name: "Ubuntu 22.04",
+            name: "Ubuntu 20.04",
             os: ubuntu-latest,
-            container_image: "ubuntu:22.04"
+            container_image: "ubuntu:20.04"
           }
         - {
-            name: "Ubuntu 22.04 ARM64",
+            name: "Ubuntu 20.04 ARM64",
             os: ubuntu-24.04-arm,
-            container_image: "ubuntu:22.04"
+            container_image: "ubuntu:20.04"
           }
 
     runs-on: ${{ matrix.config.os }}
@@ -45,6 +45,11 @@ jobs:
         uses: ilammy/setup-nasm@v1.2.1
       - name: Setup build tools for containers
         if: matrix.config.container_image != null
+        env:
+          # Prevent tzdata (pulled in by cmake/build-essential) from launching an
+          # interactive timezone prompt that hangs the build with no TTY attached.
+          DEBIAN_FRONTEND: noninteractive
+          TZ: Etc/UTC
         run: |
           apt-get update
           apt-get install -y build-essential git libssl-dev zlib1g-dev file zip curl jq cmake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,10 @@ jobs:
         #     name: "Ubuntu 24.04",
         #     os: ubuntu-24.04
         #   }
-        # - {
-        #     name: "Ubuntu 24.04 ARM",
-        #     os: ubuntu-24.04-arm
-        #   }
+        - {
+            name: "Ubuntu 24.04 ARM",
+            os: ubuntu-24.04-arm
+          }
         - {
             name: "Debian Bookworm",
             os: ubuntu-latest,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,7 @@
 name: Build
 on:
   push:
-    branches: [ dockerbuild ]
-
-permissions:
-  contents: write
-
+    branches: [ master ]
 jobs:
   build:
     strategy:
@@ -34,7 +30,6 @@ jobs:
     runs-on: ${{ matrix.config.os }}
     container:
       image: ${{ matrix.config.container_image }}
-      options: --user root
 
     steps:
       - name: Setup Windows
@@ -85,7 +80,7 @@ jobs:
           node-version: 26
       - name: Update binaries
         run: |
-          git clone --recursive https://github.com/andygruber/uWebSockets.js.git -b dockerbuild
+          git clone --recursive https://github.com/uNetworking/uWebSockets.js.git -b master
           cd uWebSockets.js
           ${{ matrix.config.os == 'windows-latest' && 'nmake' || 'make' }}
           ls dist
@@ -95,11 +90,11 @@ jobs:
           git checkout binaries
           cp dist/*.node .
           cp dist/*.js .
-          git rev-parse origin/dockerbuild > source_commit
+          git rev-parse origin/master > source_commit
           ls
-          ${{ matrix.config.os != 'windows-latest' && 'git checkout dockerbuild docs/index.d.ts && mv docs/index.d.ts .' || '' }}
+          ${{ matrix.config.os != 'windows-latest' && 'git checkout master docs/index.d.ts && mv docs/index.d.ts .' || '' }}
           git status
           git config --global user.email "alexhultman@gmail.com"
           git config --global user.name "Alex Hultman"
           git commit -a -m "[GitHub Actions] Updated ${{ matrix.config.os }} binaries" || true
-          git push "https://andygruber:${{ secrets.SECRET }}@github.com/andygruber/uWebSockets.js" binaries
+          git push "https://unetworkingab:${{ secrets.SECRET }}@github.com/uNetworking/uWebSockets.js" binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,11 @@ jobs:
         if: matrix.config.container_image != null
         run: |
           apt-get update
-          apt-get install -y build-essential git libssl-dev file zip curl jq cmake clang
+          apt-get install -y build-essential git libssl-dev zlib1g-dev file zip curl jq cmake clang-16
+          # Debian Bookworm's bare "clang" is clang-14, which lacks __builtin_source_location
+          # and cannot compile Node 26's V8 headers (std::source_location). Force clang-16.
+          update-alternatives --install /usr/bin/clang clang /usr/bin/clang-16 100
+          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-16 100
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Setup build tools for containers
         if: matrix.config.container_image != null
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential git libssl-dev file zip curl jq
+          apt-get update
+          apt-get install -y build-essential git libssl-dev file zip curl jq
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,14 +24,19 @@ jobs:
         #     name: "Ubuntu 24.04",
         #     os: ubuntu-24.04
         #   }
+        # - {
+        #     name: "Ubuntu 24.04 ARM",
+        #     os: ubuntu-24.04-arm
+        #   }
         - {
-            name: "Ubuntu 24.04 ARM",
-            os: ubuntu-24.04-arm
+            name: "Ubuntu 22.04",
+            os: ubuntu-latest,
+            container_image: "ubuntu:22.04"
           }
         - {
-            name: "Debian Bookworm",
-            os: ubuntu-latest,
-            container_image: "debian:bookworm-slim"
+            name: "Ubuntu 22.04 ARM64",
+            os: ubuntu-latest-arm,
+            container_image: "ubuntu:22.04"
           }
 
     runs-on: ${{ matrix.config.os }}
@@ -50,11 +55,33 @@ jobs:
         if: matrix.config.container_image != null
         run: |
           apt-get update
-          apt-get install -y build-essential git libssl-dev zlib1g-dev file zip curl jq cmake clang-16
-          # Debian Bookworm's bare "clang" is clang-14, which lacks __builtin_source_location
+          apt-get install -y build-essential git libssl-dev zlib1g-dev file zip curl jq cmake
+          # clang-16 is not in Ubuntu 22.04 (jammy), whose newest is clang-15.
+          # Add the official LLVM apt repo to install it.
+          . /etc/os-release
+          apt-get install -y wget gnupg
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm.gpg
+          echo "deb [signed-by=/usr/share/keyrings/llvm.gpg] http://apt.llvm.org/$VERSION_CODENAME/ llvm-toolchain-$VERSION_CODENAME-16 main" > /etc/apt/sources.list.d/llvm.list
+          apt-get update
+          apt-get install -y clang-16
+          # Ubuntu 22.04's bare "clang" is clang-14, which lacks __builtin_source_location
           # and cannot compile Node 26's V8 headers (std::source_location). Force clang-16.
           update-alternatives --install /usr/bin/clang clang /usr/bin/clang-16 100
           update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-16 100
+          echo "::group::Environment info"
+          echo "--- distro ---"
+          cat /etc/os-release
+          echo "--- architecture ---"
+          uname -a
+          dpkg --print-architecture
+          echo "--- glibc ---"
+          # ldd --version prints the glibc version on the first line; getconf gives it raw.
+          ldd --version | head -n 1
+          getconf GNU_LIBC_VERSION
+          echo "--- compiler ---"
+          clang --version
+          clang++ --version
+          echo "::endgroup::"
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,14 +17,14 @@ jobs:
             os: macos-15
           }
         - {
-            name: "Ubuntu 20.04",
+            name: "Ubuntu 22.04",
             os: ubuntu-latest,
-            container_image: "ubuntu:20.04"
+            container_image: "ubuntu:22.04"
           }
         - {
-            name: "Ubuntu 20.04 ARM64",
+            name: "Ubuntu 22.04 ARM64",
             os: ubuntu-24.04-arm,
-            container_image: "ubuntu:20.04"
+            container_image: "ubuntu:22.04"
           }
 
     runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        # - {
-        #     name: "Windows Latest",
-        #     os: windows-latest
-        #   }
-        # - {
-        #     name: "macOS 15",
-        #     os: macos-15
-        #   }
+        - {
+            name: "Windows Latest",
+            os: windows-latest
+          }
+        - {
+            name: "macOS 15",
+            os: macos-15
+          }
         # - {
         #     name: "Ubuntu 24.04",
         #     os: ubuntu-24.04
@@ -71,7 +71,7 @@ jobs:
           git checkout binaries
           cp dist/*.node .
           cp dist/*.js .
-          git rev-parse master > source_commit
+          git rev-parse origin/dockerbuild > source_commit
           ls
           ${{ matrix.config.os != 'windows-latest' && 'git checkout dockerbuild docs/index.d.ts && mv docs/index.d.ts .' || '' }}
           git status

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [ dockerbuild ]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     strategy:
@@ -17,19 +20,19 @@ jobs:
             name: "macOS 15",
             os: macos-15
           }
-        - {
-            name: "Ubuntu 24.04",
-            os: ubuntu-24.04
-          }
+        # - {
+        #     name: "Ubuntu 24.04",
+        #     os: ubuntu-24.04
+        #   }
         - {
             name: "Ubuntu 24.04 ARM",
             os: ubuntu-24.04-arm
           }
-        # - {
-        #     name: "Debian Bookworm",
-        #     os: ubuntu-24.04,
-        #     container_image: "debian:bookworm-slim"
-        #   }
+        - {
+            name: "Debian Bookworm",
+            os: ubuntu-latest,
+            container_image: "debian:bookworm-slim"
+          }
 
     runs-on: ${{ matrix.config.os }}
     container:
@@ -43,6 +46,11 @@ jobs:
       - name: Setup NASM for Windows
         if: matrix.config.os == 'windows-latest'
         uses: ilammy/setup-nasm@v1.2.1
+      - name: Setup build tools for containers
+        if: matrix.config.container_image != null
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential git libssl-dev file zip curl jq
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -61,9 +69,9 @@ jobs:
           cp dist/*.js .
           git rev-parse master > source_commit
           ls
-          ${{ matrix.config.os != 'windows-latest' && 'git checkout master docs/index.d.ts && mv docs/index.d.ts .' || '' }}
+          ${{ matrix.config.os != 'windows-latest' && 'git checkout dockerbuild docs/index.d.ts && mv docs/index.d.ts .' || '' }}
           git status
           git config --global user.email "andreas@gruber.info"
           git config --global user.name "Andreas Gruber"
           git commit -a -m "[GitHub Actions] Updated ${{ matrix.config.os }} binaries" || true
-          git push "https://andygruber:${{ secrets.SECRET }}@github.com/andygruber/uWebSockets.js" binaries
+          git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/andygruber/uWebSockets.js" binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,20 +1,47 @@
 name: Build
 on:
   push:
-    branches: [ master ]
+    branches: [ dockerbuild ]
+
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-15, ubuntu-24.04, ubuntu-24.04-arm]
+        config:
+        - {
+            name: "Windows Latest",
+            os: windows-latest
+          }
+        - {
+            name: "macOS 15",
+            os: macos-15
+          }
+        - {
+            name: "Ubuntu 24.04",
+            os: ubuntu-24.04
+          }
+        - {
+            name: "Ubuntu 24.04 ARM",
+            os: ubuntu-24.04-arm
+          }
+        # - {
+        #     name: "Debian Bookworm",
+        #     os: ubuntu-24.04,
+        #     container_image: "debian:bookworm-slim"
+        #   }
+
+    runs-on: ${{ matrix.config.os }}
+    container:
+      image: ${{ matrix.config.container_image }}
+      options: --user root
+
     steps:
       - name: Setup Windows
-        if: matrix.os == 'windows-latest'
+        if: matrix.config.os == 'windows-latest'
         uses: ilammy/msvc-dev-cmd@v1
       - name: Setup NASM for Windows
-        if: matrix.os == 'windows-latest'
+        if: matrix.config.os == 'windows-latest'
         uses: ilammy/setup-nasm@v1.2.1
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -22,9 +49,9 @@ jobs:
           node-version: 26
       - name: Update binaries
         run: |
-          git clone --recursive https://github.com/uNetworking/uWebSockets.js.git
+          git clone --recursive https://github.com/andygruber/uWebSockets.js.git -b dockerbuild
           cd uWebSockets.js
-          ${{ matrix.os == 'windows-latest' && 'nmake' || 'make' }}
+          ${{ matrix.config.os == 'windows-latest' && 'nmake' || 'make' }}
           ls dist
           cd tests && npm install ws && node smoke.js && cd ..
           ls dist
@@ -34,9 +61,9 @@ jobs:
           cp dist/*.js .
           git rev-parse master > source_commit
           ls
-          ${{ matrix.os != 'windows-latest' && 'git checkout master docs/index.d.ts && mv docs/index.d.ts .' || '' }}
+          ${{ matrix.config.os != 'windows-latest' && 'git checkout master docs/index.d.ts && mv docs/index.d.ts .' || '' }}
           git status
-          git config --global user.email "alexhultman@gmail.com"
-          git config --global user.name "Alex Hultman"
-          git commit -a -m "[GitHub Actions] Updated ${{ matrix.os }} binaries" || true
-          git push "https://unetworkingab:${{ secrets.SECRET }}@github.com/uNetworking/uWebSockets.js" binaries
+          git config --global user.email "andreas@gruber.info"
+          git config --global user.name "Andreas Gruber"
+          git commit -a -m "[GitHub Actions] Updated ${{ matrix.config.os }} binaries" || true
+          git push "https://andygruber:${{ secrets.SECRET }}@github.com/andygruber/uWebSockets.js" binaries

--- a/build.c
+++ b/build.c
@@ -213,8 +213,8 @@ int main() {
 
 #else
     /* Linux does not cross-compile but picks whatever arch the host is on (we run on both x64 and ARM64) */
-    build("clang-18",
-          "clang++-18",
+    build("clang",
+          "clang++",
           LINUX_LINK_EXTRAS,
           OS,
           arch);


### PR DESCRIPTION
This should prevent unplanned increasing of the supported glibc version. Ubuntu 22.04 is used here which uses glibc 2.35. That also gives support for Debian Bookworm.

This addresses partly #1176  . To fully address this a change to Ubuntu 20.04 images would be required, but this also needs to manually install cmake instead of using it from the distro repo.

Full build is available here:
https://github.com/andygruber/uWebSockets.js/actions/runs/29865474294