### PR TITLE
Optimize NativeString

### DIFF
--- a/src/Utilities.h
+++ b/src/Utilities.h
@@ -145,7 +145,7 @@ class NativeString {
     bool invalid = false;
 
     // Static thread-local state shared by all NativeString instances on this thread
-    // Pool size must be a multiple of 8 to guarantee pool_offset <= pool.size()
+    // Pool size must be a multiple of 8 because pool_offset is 8-byte aligned
     inline static thread_local std::vector<char> pool = std::vector<char>(128 * 1024);
     inline static thread_local size_t pool_offset = 0;
     inline static thread_local int ref_count = 0;
@@ -162,6 +162,10 @@ class NativeString {
         pool_offset += (size + 7) & ~size_t{7};
     }
 
+    static void clearPool() {
+        pool_offset = 0;
+    }
+
 public:
     NativeString(const NativeString&) = delete;
     NativeString& operator=(const NativeString&) = delete;
@@ -170,7 +174,7 @@ public:
 
     NativeString(Isolate *isolate, const Local<Value> &value) {
         if (ref_count == 0) {
-            pool_offset = 0; // Reset the "stack" when entering the first scope
+            clearPool();
         }
         ref_count++;
 
@@ -179,20 +183,20 @@ public:
             length = 0;
         } else if (value->IsString()) {
             Local<String> string = Local<String>::Cast(value);
-
+            const size_t stringLength = static_cast<size_t>(string->Length());
             size_t allocSize;
 
-            // Get the worst case allocation size
+            // Get the worst-case allocation size
             if (string->IsOneByte()) { // Latin-1 -> UTF-8
-                allocSize = 2 * static_cast<size_t>(string->Length());
+                allocSize = 2 * stringLength;
             } else { // UTF-16 -> UTF-8
-                allocSize = 3 * static_cast<size_t>(string->Length());
+                allocSize = 3 * stringLength;
             }
 
             // Allocate data
             data = getPoolPtr(allocSize);
             if (data == nullptr) {
-                // Worst case size can't be pooled: calculate the exact size
+                // Worst-case size can't be pooled: calculate the exact size
                 #if (V8_MAJOR_VERSION == 14)
                     allocSize = string->Utf8LengthV2(isolate);
                 #else
@@ -211,7 +215,7 @@ public:
                 }
             }
 
-            // Convert the string to UTF-8 into data and get the real length
+            // Convert to UTF-8 into data and get the number of bytes written
             #if (V8_MAJOR_VERSION == 14)
                 length = string->WriteUtf8V2(isolate, data, allocSize);
             #else
@@ -222,19 +226,17 @@ public:
             }
         } else if (value->IsArrayBufferView()) { /* DataView or TypedArray */
             Local<ArrayBufferView> arrayBufferView = Local<ArrayBufferView>::Cast(value);
-            auto contents = arrayBufferView->Buffer()->GetBackingStore();
+            Local<ArrayBuffer> arrayBuffer = arrayBufferView->Buffer();
             length = arrayBufferView->ByteLength();
-            data = (char *) contents->Data() + arrayBufferView->ByteOffset();
+            data = (char *) arrayBuffer->Data() + arrayBufferView->ByteOffset();
         } else if (value->IsArrayBuffer()) {
             Local<ArrayBuffer> arrayBuffer = Local<ArrayBuffer>::Cast(value);
-            auto contents = arrayBuffer->GetBackingStore();
-            length = contents->ByteLength();
-            data = (char *) contents->Data();
+            length = arrayBuffer->ByteLength();
+            data = (char *) arrayBuffer->Data();
         } else if (value->IsSharedArrayBuffer()) {
             Local<SharedArrayBuffer> arrayBuffer = Local<SharedArrayBuffer>::Cast(value);
-            auto contents = arrayBuffer->GetBackingStore();
-            length = contents->ByteLength();
-            data = (char *) contents->Data();
+            length = arrayBuffer->ByteLength();
+            data = (char *) arrayBuffer->Data();
         } else {
             invalid = true;
         }

--- a/src/Utilities.h
+++ b/src/Utilities.h
@@ -141,38 +141,33 @@ template <bool AllowStringView = false>
 class NativeString {
     char *data;
     size_t length;
-    bool allocated = false;
+    bool needsFree = false;
     bool invalid = false;
 
     // Static thread-local state shared by all NativeString instances on this thread
+    // Pool size must be a multiple of 8 to guarantee pool_offset <= pool.size()
     inline static thread_local std::vector<char> pool = std::vector<char>(128 * 1024);
     inline static thread_local size_t pool_offset = 0;
     inline static thread_local int ref_count = 0;
 
-    static char* alloc(size_t size) {
-        // Ensure size is a multiple of 8
-        size = (size + 7) & ~7;
-
-        // Fallback for allocations larger than the remaining pool space
-        if (pool_offset + size > pool.size()) {
-            // Mark for external cleanup if using instance-based logic
-            // (Note: In a pure static alloc, you'd need a way to track this)
-            return (char*)std::malloc(size);
+    static char* getPoolPtr(size_t size) {
+        if (size > pool.size() - pool_offset) {
+            return nullptr;
         }
-
-        char* ptr = pool.data() + pool_offset;
-        pool_offset += size;
-        return ptr;
+        return pool.data() + pool_offset;
     }
 
-    // Provided for completeness, though the "pool" doesn't actually free individual slices
-    static void free(char* ptr) {
-        if (ptr < pool.data() || ptr >= pool.data() + pool.size()) {
-            ::free(ptr);
-        }
+    static void commitPool(size_t size) {
+        // pool_offset is 8-byte aligned for access performance
+        pool_offset += (size + 7) & ~size_t{7};
     }
 
 public:
+    NativeString(const NativeString&) = delete;
+    NativeString& operator=(const NativeString&) = delete;
+    NativeString(NativeString&&) = delete;
+    NativeString& operator=(NativeString&&) = delete;
+
     NativeString(Isolate *isolate, const Local<Value> &value) {
         if (ref_count == 0) {
             pool_offset = 0; // Reset the "stack" when entering the first scope
@@ -185,23 +180,46 @@ public:
         } else if (value->IsString()) {
             Local<String> string = Local<String>::Cast(value);
 
-            /* StringView path is Latin-1, not Utf-8 */
+            size_t allocSize;
 
+            // Get the worst case allocation size
+            if (string->IsOneByte()) { // Latin-1 -> UTF-8
+                allocSize = 2 * static_cast<size_t>(string->Length());
+            } else { // UTF-16 -> UTF-8
+                allocSize = 3 * static_cast<size_t>(string->Length());
+            }
+
+            // Allocate data
+            data = getPoolPtr(allocSize);
+            if (data == nullptr) {
+                // Worst case size can't be pooled: calculate the exact size
+                #if (V8_MAJOR_VERSION == 14)
+                    allocSize = string->Utf8LengthV2(isolate);
+                #else
+                    allocSize = string->Utf8Length(isolate);
+                #endif
+
+                data = getPoolPtr(allocSize);
+                if (data == nullptr) {
+                    // Still can't be pooled: heap allocate it
+                    data = static_cast<char*>(std::malloc(allocSize));
+                    if (data == nullptr) {
+                        invalid = true;
+                        return;
+                    }
+                    needsFree = true;
+                }
+            }
+
+            // Convert the string to UTF-8 into data and get the real length
             #if (V8_MAJOR_VERSION == 14)
-                // Fallback
-                length = string->Utf8LengthV2(isolate);
-                data = alloc(length);
-                allocated = true;
-                string->WriteUtf8V2(isolate, data, length);
+                length = string->WriteUtf8V2(isolate, data, allocSize);
             #else
-                // Fallback
-                length = string->Utf8Length(isolate);
-                data = alloc(length);
-                allocated = true;
-                string->WriteUtf8(isolate, data, length, nullptr, String::WriteOptions::NO_NULL_TERMINATION);
+                length = string->WriteUtf8(isolate, data, allocSize, nullptr, String::WriteOptions::NO_NULL_TERMINATION);
             #endif
-
-
+            if (!needsFree) {
+                commitPool(length);
+            }
         } else if (value->IsArrayBufferView()) { /* DataView or TypedArray */
             Local<ArrayBufferView> arrayBufferView = Local<ArrayBufferView>::Cast(value);
             auto contents = arrayBufferView->Buffer()->GetBackingStore();
@@ -235,8 +253,8 @@ public:
 
     ~NativeString() {
         ref_count--;
-        if (allocated) {
-            free(data);
+        if (needsFree) {
+            ::free(data);
         }
     }
 };


### PR DESCRIPTION
### String pooling optimization:

For pooled strings, we can avoid calculating `Utf8Length()` by using the worst-case allocation size:
- Latin-1 -> UTF-8 = `2 * size` in worst case
- UTF-16 -> UTF-8 = `3 * size` in worst case

If this worst-case size fits in the pool buffer, we can call `WriteUtf8()` directly.
It writes the UTF-8 data into the pool and returns the exact number of bytes written. 
The pool offset is then advanced by the actual number of bytes used.

This should cover most strings thanks to the generous 128 KB pool.
If the string is too large, it fallback calculating the exact size.

### ArrayBuffer Data() function:

Since Node.js 20 the new [`ArrayBuffer::Data()`](https://v8docs.nodesource.com/node-20.3/d5/d6e/classv8_1_1_array_buffer.html#a6a77a9159b48e4248a7ef267d7335c33) function can replace `ArrayBuffer::GetBackingStore()->Data()`.
It removes the need to instantiate the `shared_ptr` and increase performance.

### Test case: 10 x `writeHeader(32 bytes, 32 bytes)`:

| Input type | Before | After | Change |
|---|---:|---:|---:|
| Binary | 152k req/sec | 155k req/sec | +2% |
| Latin-1 | 147k req/sec | 151k req/sec | +3% |
| UTF-16 | 127k req/sec | 146k req/sec | +15% |