### PR TITLE
docs: say what close() and end() do with messages already sent

### DIFF
--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -68,12 +68,15 @@ export interface WebSocket<UserData> {
     getBufferedAmount() : number;
 
     /** Gracefully closes this WebSocket. Immediately calls the close handler.
-     * A WebSocket close message is sent with code and shortMessage.
+     * A WebSocket close message is sent with code and shortMessage, and
+     * messages already passed to send() are delivered before the close.
      */
     end(code?: number, shortMessage?: RecognizedString) : void;
 
     /** Forcefully closes this WebSocket. Immediately calls the close handler.
-     * No WebSocket close message is sent.
+     * No WebSocket close message is sent. This maps to the close() syscall and
+     * inherits its effects, so messages already passed to send() are not
+     * delivered; use end() to send a last message before closing.
      */
     close() : void;
 


### PR DESCRIPTION
Following https://github.com/meteor/meteor/issues/14746#issuecomment-5647951322.

`close()` and `end()` differ in one way that the current wording leaves implicit: what happens to a message already handed to `send()`. Measured on 20.66.0, sending one frame and shutting down in the same tick:

| call | frames the client receives | close code |
|---|---:|---:|
| `socket.close()` | 0 | 1006 |
| `socket.end()` | 1 | 1005 |

```js
app.ws('/*', {
  open(socket) {
    socket.send('last message');
    if (process.env.MODE === 'end') socket.end(); else socket.close();
  },
});
```

Reading "Forcefully" and "Gracefully" as being only about the close frame, we used `close()` after a final `send()` and lost that message silently. This adds the syscall mapping you described and names the consequence, so the next reader picks `end()` without measuring first.
