### PR TITLE
Cork the timer writes in ServerSentEvents.js example

### DIFF
--- a/examples/ServerSentEvents.js
+++ b/examples/ServerSentEvents.js
@@ -31,7 +31,10 @@ const app = uWS./*SSL*/App({
   res.writeStatus('200 OK')
 
   let intervalRef = setInterval(() => {
-    res.write(serializeData({ message: 'Hello world!' }))
+    /* Writes made outside of a uWS callback, like from a timer, must be corked */
+    res.cork(() => {
+      res.write(serializeData({ message: 'Hello world!' }))
+    })
   }, 1000)
 
   res.onAborted(() => {


### PR DESCRIPTION
I ran examples/ServerSentEvents.js against the current Linux x64 binaries and streamed it with `curl -N`. The client gets its events, but the server prints this once per event:

```
Warning: uWS.HttpResponse writes must be made from within a corked callback. See documentation for uWS.HttpResponse.cork and consult the user manual.
```

The `res.write` runs from a `setInterval`, which is outside any uWS callback, so it is never corked. This is the same thing that was fixed in VideoStreamer.js in 0b33a99a. I wrapped the write in `res.cork()`.

To check, I ran the example for 3.5 seconds with curl attached. Before the change the client got 3 events and there were 3 warnings on stderr. After it, still 3 events and no warnings.

AI tools used
